### PR TITLE
CLI-rework

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "/Docker" 
+    directory: "/Docker"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       # PUBLIC_IPS: "1.2.3.4,2001:043e::1" # Set if you got static IP's
       # FRITZBOX: "192.168.178.1" # Use Fritz!BOX to obtain Public IP's
       # SLEEP: "300" # Seconds to sleep between DynDNS runs
-      # IPV4_ONLY: "FALSE" # Only set IPv4 address
-      # IPV6_ONLY: "FALSE" # Only set IPv6 address
+      # IPV4: "TRUE" # Set IPv4 address
+      # IPV6: "FALSE" # Set IPv6 address
       # DEBUG: "FALSE" # DEBUG LOGGING
     restart: unless-stopped

--- a/Docker/entrypoint.py
+++ b/Docker/entrypoint.py
@@ -24,7 +24,6 @@ if os.getenv('PUBLIC_IPS', None):
     public_ips = [x.strip() for x in os.getenv('PUBLIC_IPS', None).split(',')]
 fritzbox = os.getenv('FRITZBOX', None)
 
-
 config = Config(DEFAULT_ENDPOINT, os.getenv('APIKEY'), os.getenv('SECRETAPIKEY'))
 
 ipv4 = ipv6 = False

--- a/Docker/entrypoint.py
+++ b/Docker/entrypoint.py
@@ -3,6 +3,7 @@ import sys
 import logging
 from time import sleep
 from porkbun_ddns import PorkbunDDNS
+from porkbun_ddns.config import Config, DEFAULT_ENDPOINT
 
 logger = logging.getLogger('porkbun_ddns')
 if os.getenv('DEBUG', 'False').lower() in ('true', '1', 't'):
@@ -23,10 +24,8 @@ if os.getenv('PUBLIC_IPS', None):
     public_ips = [x.strip() for x in os.getenv('PUBLIC_IPS', None).split(',')]
 fritzbox = os.getenv('FRITZBOX', None)
 
-config = {
-    'secretapikey': os.getenv('SECRETAPIKEY'),
-    'apikey': os.getenv('APIKEY')
-}
+
+config = Config(DEFAULT_ENDPOINT, os.getenv('APIKEY'), os.getenv('SECRETAPIKEY'))
 
 ipv4 = ipv6 = False
 if os.getenv('IPV4', 'True').lower() in ('true', '1', 't'):

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ So if a value is set through the CLI and in the file, the CLI-value will be used
 $ porkbun-ddns "./config.json" domain.com my_subdomain
 
 # using the default config-file in ~/.config/porkbun-ddns-config.json
-$ porkbun-ddns domain.com my_subdomain
+$ porkbun-ddns - domain.com my_subdomain
 
 # Multiple subdomains:
 $ porkbun-ddns "./config.json" domain.com my_subdomain_1 my_subdomain_2 my_subdomain_3

--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ usage: cli.py [-h] [-c CONFIG] [-e ENDPOINT] [-pk APIKEY] [-sk SECRETAPIKEY] [-i
               domain [subdomains ...]
 
 positional arguments:
-  config                Path to config file, use '-' to disable (default: ~/.config/porkbun-ddns-
-                        config.json)
   domain                Domain to be updated
   subdomains            Subdomain(s)
 
 options:
   -h, --help            show this help message and exit
+  -c CONFIG, --config CONFIG
+                        Path to config file, use '-' to disable (default: ~/.config/porkbun-ddns-
+                        config.json)
   -e ENDPOINT, --endpoint ENDPOINT
                         The endpoint
   -pk APIKEY, --apikey APIKEY
@@ -76,25 +77,23 @@ So if a value is set through the CLI and in the file, the CLI-value will be used
 ### Examples
 
 ```shell
-$ porkbun-ddns "./config.json" domain.com my_subdomain
-
-# using the default config-file in ~/.config/porkbun-ddns-config.json
-$ porkbun-ddns - domain.com my_subdomain
-
-# Multiple subdomains:
-$ porkbun-ddns "./config.json" domain.com my_subdomain_1 my_subdomain_2 my_subdomain_3
-
-# Set root and subdomains:
-$ porkbun-ddns "./config.json" domain.com @ my_subdomain_1 my_subdomain_2 my_subdomain_3
-
-# Get config from environment variable:
+# using the default config-file in ~/.config/porkbun-ddns-config.json or from environment variables:
 # PORKBUN_APIKEY
 # PORKBUN_SECRETAPIKEY
 # PORKBUN_ENDPOINT (Optional)
-$ porkbun-ddns - domain.com my_subdomain
+$ porkbun-ddns domain.com my_subdomain
+
+# Specific config-file:
+$ porkbun-ddns domain.com my_subdomain -c "./config.json"
+
+# Multiple subdomains:
+$ porkbun-ddns domain.com my_subdomain_1 my_subdomain_2 my_subdomain_3
+
+# Set root and subdomains:
+$ porkbun-ddns domain.com @ my_subdomain_1 my_subdomain_2 my_subdomain_3
 
 # Set IP's explicit
-$ porkbun-ddns "./config.json" domain.com my_subdomain -i '1.2.3.4' '1234:abcd:0:4567::8900'
+$ porkbun-ddns domain.com my_subdomain -i '1.2.3.4' '1234:abcd:0:4567::8900'
 
 # Use Fritz!Box to obtain IP's and set IPv4 A Record only
 $ porkbun-ddns "./config.json" domain.com my_subdomain -f fritz.box -4

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ If this is not enabled, you'll see an error about your API keys being invalid, d
 
 # CLI
 
+**Minimum required python version: 3.10**
+
 ## Install via pip
 
 ```shell
@@ -34,10 +36,7 @@ pip install porkbun-ddns
 ## Usage
 
 ```Shell
-$ porkbun-ddns -h
-usage: cli.py [-h] [-c CONFIG] [-e ENDPOINT] [-pk APIKEY] [-sk SECRETAPIKEY] [-i [PUBLIC_IPS ...]]
-              [-f FRITZBOX] [-4 | -6] [-v]
-              domain [subdomains ...]
+usage: porkbun-ddns [-h] [-c CONFIG] [-e ENDPOINT] [-pk APIKEY] [-sk SECRETAPIKEY] [-i [PUBLIC_IPS ...]] [-f FRITZBOX] [-4 | -6] [-v] [--env_only] domain [subdomains ...]
 
 positional arguments:
   domain                Domain to be updated
@@ -46,8 +45,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -c CONFIG, --config CONFIG
-                        Path to config file, use '-' to disable (default: ~/.config/porkbun-ddns-
-                        config.json)
+                        Path to config file (default: ~/.config/porkbun-ddns-config.json)
   -e ENDPOINT, --endpoint ENDPOINT
                         The endpoint
   -pk APIKEY, --apikey APIKEY
@@ -61,7 +59,7 @@ options:
   -4, --ipv4-only       Only set/update IPv4 A Records
   -6, --ipv6-only       Only set/update IPv6 AAAA Records
   -v, --verbose         Show Debug Output
-
+  --env_only            Don't use any config, get all variables from the environment
 ```
 
 ### The parameter *endpoint*, *apikey*, *secretapikey*
@@ -77,11 +75,14 @@ So if a value is set through the CLI and in the file, the CLI-value will be used
 ### Examples
 
 ```shell
-# using the default config-file in ~/.config/porkbun-ddns-config.json or from environment variables:
+# using the default config-file in ~/.config/porkbun-ddns-config.json:
+$ porkbun-ddns domain.com my_subdomain
+
+# Using only environment variables:
 # PORKBUN_APIKEY
 # PORKBUN_SECRETAPIKEY
 # PORKBUN_ENDPOINT (Optional)
-$ porkbun-ddns domain.com my_subdomain
+$ porkbun-ddns domain.com my_subdomain --env_only
 
 # Specific config-file:
 $ porkbun-ddns domain.com my_subdomain -c "./config.json"
@@ -155,7 +156,7 @@ docker run -d \
 
 # Python
 
-**Minimum required version: 3.10**
+**Minimum required python version: 3.10**
 
 ```python
 from pathlib import Path

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ docker run -d \
 
 # Python
 
+**Minimum required version: 3.10**
+
 ```python
 from pathlib import Path
 from porkbun_ddns import PorkbunDDNS

--- a/README.md
+++ b/README.md
@@ -40,14 +40,13 @@ usage: cli.py [-h] [-c CONFIG] [-e ENDPOINT] [-pk APIKEY] [-sk SECRETAPIKEY] [-i
               domain [subdomains ...]
 
 positional arguments:
+  config                Path to config file, use '-' to disable (default: ~/.config/porkbun-ddns-
+                        config.json)
   domain                Domain to be updated
   subdomains            Subdomain(s)
 
 options:
   -h, --help            show this help message and exit
-  -c CONFIG, --config CONFIG
-                        Path to config file, use '-' to disable (default: ~/.config/porkbun-ddns-
-                        config.json)
   -e ENDPOINT, --endpoint ENDPOINT
                         The endpoint
   -pk APIKEY, --apikey APIKEY
@@ -77,16 +76,16 @@ So if a value is set through the CLI and in the file, the CLI-value will be used
 ### Examples
 
 ```shell
-$ porkbun-ddns -c "./config.json" domain.com my_subdomain
+$ porkbun-ddns "./config.json" domain.com my_subdomain
 
 # using the default config-file in ~/.config/porkbun-ddns-config.json
 $ porkbun-ddns domain.com my_subdomain
 
 # Multiple subdomains:
-$ porkbun-ddns -c "./config.json" domain.com my_subdomain_1 my_subdomain_2 my_subdomain_3
+$ porkbun-ddns "./config.json" domain.com my_subdomain_1 my_subdomain_2 my_subdomain_3
 
 # Set root and subdomains:
-$ porkbun-ddns -c "./config.json" domain.com @ my_subdomain_1 my_subdomain_2 my_subdomain_3
+$ porkbun-ddns "./config.json" domain.com @ my_subdomain_1 my_subdomain_2 my_subdomain_3
 
 # Get config from environment variable:
 # PORKBUN_APIKEY

--- a/README.md
+++ b/README.md
@@ -35,15 +35,25 @@ pip install porkbun-ddns
 
 ```Shell
 $ porkbun-ddns -h
-usage: porkbun-ddns [-h] [-i [PUBLIC_IPS ...]] [-f FRITZBOX] [-4 | -6] config domain [subdomain]
+usage: cli.py [-h] [-c CONFIG] [-e ENDPOINT] [-pk APIKEY] [-sk SECRETAPIKEY] [-i [PUBLIC_IPS ...]]
+              [-f FRITZBOX] [-4 | -6] [-v]
+              domain [subdomains ...]
 
 positional arguments:
-  config                Path to config file
   domain                Domain to be updated
-  subdomain             Subdomain
+  subdomains            Subdomain(s)
 
 options:
   -h, --help            show this help message and exit
+  -c CONFIG, --config CONFIG
+                        Path to config file, use '-' to disable (default: ~/.config/porkbun-ddns-
+                        config.json)
+  -e ENDPOINT, --endpoint ENDPOINT
+                        The endpoint
+  -pk APIKEY, --apikey APIKEY
+                        The Porkbun-API-key
+  -sk SECRETAPIKEY, --secretapikey SECRETAPIKEY
+                        The secret API-key
   -i [PUBLIC_IPS ...], --public-ips [PUBLIC_IPS ...]
                         Public IPs (v4 and or v6)
   -f FRITZBOX, --fritzbox FRITZBOX
@@ -51,23 +61,37 @@ options:
   -4, --ipv4-only       Only set/update IPv4 A Records
   -6, --ipv6-only       Only set/update IPv6 AAAA Records
   -v, --verbose         Show Debug Output
+
 ```
 
-Examples:
+### The parameter *endpoint*, *apikey*, *secretapikey*
+
+These parameter are required for each run of the program. The program will take the values for these (in this order) from:
+
+1. The command-line-arguments (`-pk pk1_xxx`)
+2. The environment-variables (`export PORKBUN_APIKEY='pk1_xxx'`)
+3. The config-file (`apikey="pk_xxx"`)
+
+So if a value is set through the CLI and in the file, the CLI-value will be used. This allows for a default-configuration in the config-file, whose settings can be selectively overridden through enviromnment-variables or CLI-arguments.
+
+### Examples
 
 ```shell
-$ porkbun-ddns "./config.json" domain.com my_subdomain
+$ porkbun-ddns -c "./config.json" domain.com my_subdomain
+
+# using the default config-file in ~/.config/porkbun-ddns-config.json
+$ porkbun-ddns domain.com my_subdomain
 
 # Multiple subdomains:
-$ porkbun-ddns "./config.json" domain.com my_subdomain_1 my_subdomain_2 my_subdomain_3
+$ porkbun-ddns -c "./config.json" domain.com my_subdomain_1 my_subdomain_2 my_subdomain_3
 
 # Set root and subdomains:
-$ porkbun-ddns "./config.json" domain.com @ my_subdomain_1 my_subdomain_2 my_subdomain_3
+$ porkbun-ddns -c "./config.json" domain.com @ my_subdomain_1 my_subdomain_2 my_subdomain_3
 
 # Get config from environment variable:
 # PORKBUN_APIKEY
 # PORKBUN_SECRETAPIKEY
-# PORKBUN_DDNS_ENDPOINT (Optional)
+# PORKBUN_ENDPOINT (Optional)
 $ porkbun-ddns - domain.com my_subdomain
 
 # Set IP's explicit
@@ -86,7 +110,8 @@ You can set up a cron job get the full path to porkbun-ddns with `which porkbun-
 `config.json` example:
 
 ```
-{ "endpoint":"https://porkbun.com/api/json/v3",
+{
+  "endpoint":"https://porkbun.com/api/json/v3",
   "apikey": "pk1_xxx",
   "secretapikey": "sk1_xxx"
 }
@@ -133,17 +158,17 @@ docker run -d \
 # Python
 
 ```python
+from pathlib import Path
 from porkbun_ddns import PorkbunDDNS
+from porkbun_ddns.config import Config, DEFAULT_ENDPOINT, extract_config
 
-config = {
-    'secretapikey': 'YOUR-SECRETAPIKEY',
-    'apikey': 'YOUR-APIKEY'
-}
 
+config = Config(DEFAULT_ENDPOINT, "YOUR-APIKEY", "YOUR-SECRETAPIKEY")
 porkbun_ddns = PorkbunDDNS(config, 'domain.com')
-# porkbun_ddns = PorkbunDDNS('./config.json', 'domain.com')
-# porkbun_ddns_ip = PorkbunDDNS('./config.json', 'domain.com', public_ips=['1.2.3.4','1234:abcd:0:4567::8900'])
-# porkbun_ddns_fritz = PorkbunDDNS('./config.json', 'domain.com', fritzbox='fritz.box', ipv6=False)
+# config = extract_config(Path("./config.json"))
+# porkbun_ddns = PorkbunDDNS(config, 'domain.com')
+# porkbun_ddns_ip = PorkbunDDNS(config, 'domain.com', public_ips=['1.2.3.4','1234:abcd:0:4567::8900'])
+# porkbun_ddns_fritz = PorkbunDDNS(config, 'domain.com', fritzbox='fritz.box', ipv6=False)
 
 porkbun_ddns.set_subdomain('my_subdomain')
 porkbun_ddns.update_records()

--- a/porkbun_ddns/__init__.py
+++ b/porkbun_ddns/__init__.py
@@ -1,2 +1,1 @@
-from .porkbun_ddns import PorkbunDDNS
-from .porkbun_ddns import PorkbunDDNS_Error
+from .porkbun_ddns import PorkbunDDNS, PorkbunDDNS_Error

--- a/porkbun_ddns/__init__.py
+++ b/porkbun_ddns/__init__.py
@@ -1,1 +1,1 @@
-from .porkbun_ddns import PorkbunDDNS, PorkbunDDNS_Error
+from .porkbun_ddns import PorkbunDDNS

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -21,8 +21,7 @@ def main(argv=sys.argv[1:]):
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("config", help=f"Path to config file, use '-' to disable "
-                        f"(default: {get_config_file_default()})",
-                        default=get_config_file_default())
+                        f"(default: {get_config_file_default()})")
     parser.add_argument("domain", help="Domain to be updated")
 
     parser.add_argument("-e", "--endpoint", help="The endpoint")
@@ -58,7 +57,7 @@ def main(argv=sys.argv[1:]):
         args = parser.parse_args(argv)
 
         if args.config == "-":
-            args.config = None
+            args.config = get_config_file_default()
         config = extract_config(args)
         ipv4 = args.ipv4_only
         ipv6 = args.ipv6_only

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -20,7 +20,7 @@ def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("config", help=f"Path to config file, use '-' to disable "
+    parser.add_argument("config", help=f"Path to config file, use '-' to use default "
                         f"(default: {get_config_file_default()})")
     parser.add_argument("domain", help="Domain to be updated")
 

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -4,8 +4,8 @@ import sys
 import traceback
 
 from porkbun_ddns import PorkbunDDNS
-from porkbun_ddns.errors import PorkbunDDNS_Error
 from porkbun_ddns.config import extract_config, get_config_file_default
+from porkbun_ddns.errors import PorkbunDDNS_Error
 
 logger = logging.getLogger("porkbun_ddns")
 logger.setLevel(logging.INFO)

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -1,23 +1,23 @@
 import argparse
+import logging
 import sys
 import traceback
-import logging
 
 from porkbun_ddns import PorkbunDDNS, PorkbunDDNS_Error
-from porkbun_ddns.config import get_config_file_default, extract_config
+from porkbun_ddns.config import extract_config, get_config_file_default
 
-logger = logging.getLogger('porkbun_ddns')
+logger = logging.getLogger("porkbun_ddns")
 logger.setLevel(logging.INFO)
 handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(message)s')
+formatter = logging.Formatter("%(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
     parser.add_argument("domain", help="Domain to be updated")
@@ -30,25 +30,25 @@ def main(argv=sys.argv[1:]):
     parser.add_argument("-sk", "--secretapikey", help="The secret API-key")
 
     subdomains = parser.add_mutually_exclusive_group()
-    subdomains.add_argument('subdomains', nargs='*',
+    subdomains.add_argument("subdomains", nargs="*",
                            default=None, help="Subdomain(s)")
 
     public_ips = parser.add_mutually_exclusive_group()
-    public_ips.add_argument('-i', '--public-ips', nargs='*',
+    public_ips.add_argument("-i", "--public-ips", nargs="*",
                             default=None, help="Public IPs (v4 and or v6)")
 
     fritzbox = parser.add_mutually_exclusive_group()
-    fritzbox.add_argument('-f', '--fritzbox', default=None,
+    fritzbox.add_argument("-f", "--fritzbox", default=None,
                           help="IP or Domain of your Fritz!Box")
 
     ip = parser.add_mutually_exclusive_group()
-    ip.add_argument('-4', '--ipv4-only', action='store_true',
+    ip.add_argument("-4", "--ipv4-only", action="store_true",
                     help="Only set/update IPv4 A Records")
-    ip.add_argument('-6', '--ipv6-only', action='store_true',
+    ip.add_argument("-6", "--ipv6-only", action="store_true",
                     help="Only set/update IPv6 AAAA Records")
 
     verbose = parser.add_mutually_exclusive_group()
-    verbose.add_argument('-v', '--verbose', action='store_true',
+    verbose.add_argument("-v", "--verbose", action="store_true",
                     help="Show Debug Output")
 
     if not argv:
@@ -88,5 +88,5 @@ def main(argv=sys.argv[1:]):
         logger.error(traceback.format_exc())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -22,7 +22,7 @@ def main(argv=sys.argv[1:]):
     )
     parser.add_argument("domain", help="Domain to be updated")
 
-    parser.add_argument("-c", "--config", help=f"Path to config file, use '-' to disable "
+    parser.add_argument("-c", "--config", help=f"Path to config file "
                                                f"(default: {get_config_file_default()})",
                         default=get_config_file_default())
     parser.add_argument("-e", "--endpoint", help="The endpoint")
@@ -51,6 +51,11 @@ def main(argv=sys.argv[1:]):
     verbose.add_argument("-v", "--verbose", action="store_true",
                     help="Show Debug Output")
 
+    env_only = parser.add_mutually_exclusive_group()
+    env_only.add_argument("--env_only", action="store_true",
+                    help="Don't use any config, "
+                    "get all variables from the environment")
+
     if not argv:
         parser.print_help()
         exit(1)
@@ -70,11 +75,6 @@ def main(argv=sys.argv[1:]):
         ipv6 = args.ipv6_only
         if not any([ipv4, ipv6]):
             ipv4 = ipv6 = True
-
-        if args.verbose:
-            logger.setLevel(logging.DEBUG)
-            for handler in logger.handlers:
-                handler.setLevel(logging.DEBUG)
 
         porkbun_ddns = PorkbunDDNS(config=config, domain=args.domain,
                                    public_ips=args.public_ips, fritzbox_ip=args.fritzbox,

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -19,11 +19,10 @@ def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-
-    parser.add_argument("domain", help="Domain to be updated")
-    parser.add_argument("-c", "--config", help=f"Path to config file, use '-' to disable "
-                                               f"(default: {get_config_file_default()})",
+    parser.add_argument("config", help=f"Path to config file, use '-' to disable "
+                        f"(default: {get_config_file_default()})",
                         default=get_config_file_default())
+    parser.add_argument("domain", help="Domain to be updated")
 
     parser.add_argument("-e", "--endpoint", help="The endpoint")
     parser.add_argument("-pk", "--apikey", help="The Porkbun-API-key")

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -19,7 +19,7 @@ def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("config", help=f"Path to config file, use '-' to disable "
+    parser.add_argument("config", help=f"Path to config file, use '-' to disable"
                         f"(default: {get_config_file_default()})",
                         default=get_config_file_default())
     parser.add_argument("domain", help="Domain to be updated")
@@ -50,9 +50,9 @@ def main(argv=sys.argv[1:]):
     verbose.add_argument("-v", "--verbose", action="store_true",
                     help="Show Debug Output")
 
-    if not argv:
+    if argv and len(argv) == 1:
         parser.print_help()
-        exit()
+        exit(1)
 
     args = parser.parse_args(argv)
 

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -20,10 +20,11 @@ def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("config", help=f"Path to config file, use '-' to use default "
-                        f"(default: {get_config_file_default()})")
     parser.add_argument("domain", help="Domain to be updated")
 
+    parser.add_argument("-c", "--config", help=f"Path to config file, use '-' to disable "
+                                               f"(default: {get_config_file_default()})",
+                        default=get_config_file_default())
     parser.add_argument("-e", "--endpoint", help="The endpoint")
     parser.add_argument("-pk", "--apikey", help="The Porkbun-API-key")
     parser.add_argument("-sk", "--secretapikey", help="The secret API-key")

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -57,8 +57,14 @@ def main(argv=sys.argv[1:]):
     try:
         args = parser.parse_args(argv)
 
-        if args.config == "-":
-            args.config = get_config_file_default()
+        if args.env_only:
+            args.config = None
+
+        if args.verbose:
+            logger.setLevel(logging.DEBUG)
+            for handler in logger.handlers:
+                handler.setLevel(logging.DEBUG)
+
         config = extract_config(args)
         ipv4 = args.ipv4_only
         ipv6 = args.ipv6_only

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -81,7 +81,7 @@ class _Config:
             return str(param)
         if self.config_file_content and (param := self.config_file_content.get(option_name, None)):
             return str(param)
-        raise ValueError(
+        raise PorkbunDDNS_Error(
             f"'{option_name}' is not defined via CLI-arguments,"
             f" as an environment-variable"
             f" nor in the config-file ("

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -42,8 +42,8 @@ def load_config_file(config_file: Path | None) -> dict[str, str] | None:
             config = json.load(cf)
             required_keys = ["secretapikey", "apikey"]
             if all(x not in config for x in required_keys):
-                raise PorkbunDDNS_Error(f"Missing keys! All of the following are required: '{
-                                        required_keys}'\nYour config:\n{config}")
+                raise PorkbunDDNS_Error(f"Missing keys! All of the following are required: \
+                    '{required_keys}'\nYour config:\n{config}")
     return config
 
 
@@ -98,5 +98,5 @@ def extract_config(extract_from: argparse.Namespace | Path) -> Config:
         if content := load_config_file(extract_from):
             return Config(**content)
         raise ValueError(f"Not a file: {extract_from}")
-    raise TypeError(f"{extract_from} is of type {
-                    type(extract_from)}, not Namespace/Path")
+    raise TypeError(f"{extract_from} is of type \
+        {type(extract_from)}, not Namespace/Path")

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -25,13 +25,13 @@ config_file_default_content: Final = \
 def get_config_file_default() -> Path:
     if not xdg.xdg_config_home().is_dir():
         os.makedirs(xdg.xdg_config_home())
-        logger.debug("Generating config home: %s", xdg.xdg_config_home())
+        logger.info("Generating config home: %s", xdg.xdg_config_home())
 
     config_file_name = "porkbun-ddns-config.json"
     config_file_path = xdg.xdg_config_home() / config_file_name
     if not config_file_path.is_file():
         config_file_path.write_text(config_file_default_content)
-        logger.debug("Wrote config to: %s", config_file_path)
+        logger.info("Wrote config to: %s", config_file_path)
     return config_file_path
 
 

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 from typing import Final, NamedTuple
 
-import xdg
+import xdg_base_dirs as xdg
 
 from porkbun_ddns.errors import PorkbunDDNS_Error
 
@@ -21,7 +21,6 @@ config_file_default_content: Final = \
     "secretapikey": ""
 }}
 """
-
 
 def get_config_file_default() -> Path:
     if not xdg.xdg_config_home().is_dir():

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -83,7 +83,7 @@ class _Config:
             f")"
         )
 
-
+# TODO: This needs rework:
 def extract_config(extract_from: Union[argparse.Namespace, Path]) -> Config:
     """Extracts a Config-object, either from an argparse-Namespace or from  a Path to a config-file"""
     if isinstance(extract_from, argparse.Namespace):
@@ -93,4 +93,3 @@ def extract_config(extract_from: Union[argparse.Namespace, Path]) -> Config:
             return Config(**content)
         raise ValueError(f"Not a file: {extract_from}")
     raise TypeError(f"{extract_from} is of type {type(extract_from)}, not Namespace/Path")
-

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -3,11 +3,11 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Final, NamedTuple, Optional, Union
+from typing import Final, NamedTuple
 
 import xdg
 
-logger = logging.getLogger('porkbun_ddns')
+logger = logging.getLogger("porkbun_ddns")
 
 DEFAULT_ENDPOINT: Final = "https://porkbun.com/api/json/v3"
 
@@ -32,7 +32,7 @@ def get_config_file_default() -> Path:
     return config_file_path
 
 
-def load_config_file(config_file: Optional[Path]) -> Optional[dict[str, str]]:
+def load_config_file(config_file: Path | None) -> dict[str, str] | None:
     if config_file:
         if not config_file.is_file():
             raise ValueError("Not a file: %s", config_file)
@@ -63,8 +63,7 @@ class _Config:
         return Config(**self.options)
 
     def _get_option_value(self, option_name: str) -> str:
-        """
-        Tries to get a value for the option_name from the program-arguments first,
+        """Tries to get a value for the option_name from the program-arguments first,
         then from the environment-variables second and last from the config-file.
         Raises ValueError if nothing is found
         """
@@ -80,11 +79,11 @@ class _Config:
             f" as an environment-variable"
             f" nor in the config-file ("
             f"{self.config_file_path if self.config_file_path else 'no config-file defined'}"
-            f")"
+            f")",
         )
 
 # TODO: This needs rework:
-def extract_config(extract_from: Union[argparse.Namespace, Path]) -> Config:
+def extract_config(extract_from: argparse.Namespace | Path) -> Config:
     """Extracts a Config-object, either from an argparse-Namespace or from  a Path to a config-file"""
     if isinstance(extract_from, argparse.Namespace):
         return _Config(extract_from).get_options()

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -4,9 +4,10 @@ import logging
 import os
 from pathlib import Path
 from typing import Final, NamedTuple
-from porkbun_ddns import PorkbunDDNS_Error
 
 import xdg
+
+from porkbun_ddns import PorkbunDDNS_Error
 
 logger = logging.getLogger("porkbun_ddns")
 
@@ -42,8 +43,7 @@ def load_config_file(config_file: Path | None) -> dict[str, str] | None:
             config = json.load(cf)
             required_keys = ["secretapikey", "apikey"]
             if all(x not in config for x in required_keys):
-                raise PorkbunDDNS_Error("Missing keys! All of the following are required: '{}'\nYour config:\n{}".format(
-                    required_keys, config))
+                raise PorkbunDDNS_Error(f"Missing keys! All of the following are required: '{required_keys}'\nYour config:\n{config}")
     return config
 
 

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -1,0 +1,96 @@
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Final, NamedTuple, Optional, Union
+
+import xdg
+
+logger = logging.getLogger('porkbun_ddns')
+
+DEFAULT_ENDPOINT: Final = "https://porkbun.com/api/json/v3"
+
+config_file_default_content: Final = \
+    f"""
+{{
+    "endpoint": "{DEFAULT_ENDPOINT}",
+    "apikey": "pk1_xxx",
+    "secretapikey": "sk1_xxx"
+}}
+"""
+
+
+def get_config_file_default() -> Path:
+    if not xdg.xdg_config_home().is_dir():
+        os.makedirs(xdg.xdg_config_home())
+
+    config_file_name = "porkbun-ddns-config.json"
+    config_file_path = xdg.xdg_config_home() / config_file_name
+    if not config_file_path.is_file():
+        config_file_path.write_text(config_file_default_content)
+    return config_file_path
+
+
+def load_config_file(config_file: Optional[Path]) -> Optional[dict[str, str]]:
+    if config_file:
+        if not config_file.is_file():
+            raise ValueError("Not a file: %s", config_file)
+        with config_file.open() as cf:
+            return json.load(cf)
+    return None
+
+
+class Config(NamedTuple):
+    endpoint: str
+    apikey: str
+    secretapikey: str
+
+
+class _Config:
+
+    def __init__(self, args: argparse.Namespace):
+        self.args = args
+        self.config_file_path = None
+        self.config_file_content = None
+        if config_file := getattr(args, "config", None):
+            self.config_file_path = Path(config_file)
+            self.config_file_content = load_config_file(self.config_file_path)
+
+        self.options = {name: self._get_option_value(name) for name in Config._fields}
+
+    def get_options(self) -> Config:
+        return Config(**self.options)
+
+    def _get_option_value(self, option_name: str) -> str:
+        """
+        Tries to get a value for the option_name from the program-arguments first,
+        then from the environment-variables second and last from the config-file.
+        Raises ValueError if nothing is found
+        """
+        if param := getattr(self.args, option_name, None):
+            return str(param)
+        env_option_name = "PORKBUN_" + option_name.upper()
+        if param := os.environ.get(env_option_name, None):
+            return str(param)
+        if self.config_file_content and (param := self.config_file_content.get(option_name, None)):
+            return str(param)
+        raise ValueError(
+            f"'{option_name}' is not defined via CLI-arguments,"
+            f" as an environment-variable"
+            f" nor in the config-file ("
+            f"{self.config_file_path if self.config_file_path else 'no config-file defined'}"
+            f")"
+        )
+
+
+def extract_config(extract_from: Union[argparse.Namespace, Path]) -> Config:
+    """Extracts a Config-object, either from an argparse-Namespace or from  a Path to a config-file"""
+    if isinstance(extract_from, argparse.Namespace):
+        return _Config(extract_from).get_options()
+    if isinstance(extract_from, Path):
+        if content := load_config_file(extract_from):
+            return Config(**content)
+        raise ValueError(f"Not a file: {extract_from}")
+    raise TypeError(f"{extract_from} is of type {type(extract_from)}, not Namespace/Path")
+

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -7,7 +7,7 @@ from typing import Final, NamedTuple
 
 import xdg
 
-from porkbun_ddns import PorkbunDDNS_Error
+from porkbun_ddns.errors import PorkbunDDNS_Error
 
 logger = logging.getLogger("porkbun_ddns")
 
@@ -43,7 +43,8 @@ def load_config_file(config_file: Path | None) -> dict[str, str] | None:
             config = json.load(cf)
             required_keys = ["secretapikey", "apikey"]
             if all(x not in config for x in required_keys):
-                raise PorkbunDDNS_Error(f"Missing keys! All of the following are required: '{required_keys}'\nYour config:\n{config}")
+                raise PorkbunDDNS_Error(f"Missing keys! All of the following are required: '{
+                                        required_keys}'\nYour config:\n{config}")
     return config
 
 
@@ -94,5 +95,9 @@ def extract_config(extract_from: argparse.Namespace | Path) -> Config:
     """Extracts a Config-object, either from an argparse-Namespace or from  a Path to a config-file"""
     if isinstance(extract_from, argparse.Namespace):
         return _Config(extract_from).get_options()
+    if isinstance(extract_from, Path):
+        if content := load_config_file(extract_from):
+            return Config(**content)
+        raise ValueError(f"Not a file: {extract_from}")
     raise TypeError(f"{extract_from} is of type {
                     type(extract_from)}, not Namespace/Path")

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -25,11 +25,13 @@ config_file_default_content: Final = \
 def get_config_file_default() -> Path:
     if not xdg.xdg_config_home().is_dir():
         os.makedirs(xdg.xdg_config_home())
+        logger.debug("Generating config home: %s", xdg.xdg_config_home())
 
     config_file_name = "porkbun-ddns-config.json"
     config_file_path = xdg.xdg_config_home() / config_file_name
     if not config_file_path.is_file():
         config_file_path.write_text(config_file_default_content)
+        logger.debug("Wrote config to: %s", config_file_path)
     return config_file_path
 
 
@@ -40,6 +42,7 @@ def load_config_file(config_file: Path | None) -> dict[str, str] | None:
             raise ValueError("Not a file: %s", config_file)
         with config_file.open() as cf:
             config = json.load(cf)
+            logger.debug("Loaded config from: %s", config_file)
             required_keys = ["secretapikey", "apikey"]
             if all(x not in config for x in required_keys):
                 raise PorkbunDDNS_Error(f"Missing keys! All of the following are required: \
@@ -62,7 +65,8 @@ class _Config:
         if config_file := getattr(args, "config", None):
             self.config_file_path = Path(config_file)
             self.config_file_content = load_config_file(self.config_file_path)
-
+        else:
+            logger.debug("Skiped loading config file")
         self.options = {name: self._get_option_value(
             name) for name in Config._fields}
 

--- a/porkbun_ddns/errors.py
+++ b/porkbun_ddns/errors.py
@@ -1,0 +1,2 @@
+class PorkbunDDNS_Error(Exception):
+    pass

--- a/porkbun_ddns/helpers.py
+++ b/porkbun_ddns/helpers.py
@@ -1,6 +1,6 @@
+import logging
 import urllib.request
 import xml.etree.ElementTree as ET
-import logging
 
 logger = logging.getLogger()
 
@@ -9,32 +9,35 @@ def get_ips_from_fritzbox(fritzbox_ip):
     """Retrieves the IP address of the Fritzbox router's external network interface.
 
     Args:
+    ----
         fritzbox_ip (str): The IP address of the Fritzbox router.
 
     Returns:
+    -------
         str: The IP address of the Fritzbox router's external network interface.
 
     Raises:
+    ------
         urllib.error.URLError: If there is a problem opening the URL.
 
         ValueError: If the provided `fritzbox_ip` is not a valid IP address.
 
         AttributeError: If the requested field is not found in the XML response.
-    """
 
-    schema = 'GetExternalIPAddress'
-    field = 'NewExternalIPAddress'
+    """
+    schema = "GetExternalIPAddress"
+    field = "NewExternalIPAddress"
 
     req = urllib.request.Request(
-        'http://' + fritzbox_ip + ':49000/igdupnp/control/WANIPConn1')
-    req.add_header('Content-Type', 'text/xml; charset="utf-8"')
+        "http://" + fritzbox_ip + ":49000/igdupnp/control/WANIPConn1")
+    req.add_header("Content-Type", 'text/xml; charset="utf-8"')
     req.add_header(
-        'SOAPAction', 'urn:schemas-upnp-org:service:WANIPConnection:1#' + schema)
+        "SOAPAction", "urn:schemas-upnp-org:service:WANIPConnection:1#" + schema)
     data = '<?xml version="1.0" encoding="utf-8"?>' + \
         '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">' + \
-        '<s:Body>' + \
-        '<u:' + schema + ' xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1" />' + \
-        '</s:Body>' + \
-        '</s:Envelope>'
-    req.data = data.encode('utf8')
-    return ET.fromstring(urllib.request.urlopen(req).read()).find('.//' + field).text
+        "<s:Body>" + \
+        "<u:" + schema + ' xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1" />' + \
+        "</s:Body>" + \
+        "</s:Envelope>"
+    req.data = data.encode("utf8")
+    return ET.fromstring(urllib.request.urlopen(req).read()).find(".//" + field).text

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -5,6 +5,8 @@ import json
 from ipaddress import IPv4Address, IPv6Address, ip_address
 import urllib.request
 from urllib.error import HTTPError, URLError
+
+from porkbun_ddns.config import Config
 from porkbun_ddns.helpers import get_ips_from_fritzbox
 
 logger = logging.getLogger('porkbun_ddns')
@@ -86,28 +88,30 @@ class PorkbunDDNS():
             else:
                 if self.ipv4:
                     urls = ['https://v4.ident.me',
-                    'https://api.ipify.org',
-                    'https://ipv4.icanhazip.com']
+                            'https://api.ipify.org',
+                            'https://ipv4.icanhazip.com']
                     try:
                         for url in urls:
                             with urllib.request.urlopen(url) as response:
                                 if response.getcode() == 200:
                                     public_ips.append(response.read().decode('utf-8'))
                                     break
-                                logger.warning("Failed to retrieve IPv4 Address from %s! HTTP status code: %s", url, str(response.code()))
+                                logger.warning("Failed to retrieve IPv4 Address from %s! HTTP status code: %s", url,
+                                               str(response.code()))
                     except URLError:
                         logger.warning("Can't reach IPv4 Address! Check IPv4 connectivity!")
                 if self.ipv6:
                     urls = ['https://v6.ident.me',
-                    'https://api6.ipify.org',
-                    'https://ipv6.icanhazip.com']
+                            'https://api6.ipify.org',
+                            'https://ipv6.icanhazip.com']
                     try:
                         for url in urls:
                             with urllib.request.urlopen(url) as response:
                                 if response.getcode() == 200:
                                     public_ips.append(response.read().decode('utf-8'))
                                     break
-                                logger.warning("Failed to retrieve IPv6 Address from %s! HTTP status code: %s", url, str(response.code()))
+                                logger.warning("Failed to retrieve IPv6 Address from %s! HTTP status code: %s", url,
+                                               str(response.code()))
                     except URLError:
                         logger.warning("Can't reach IPv6 Address! Check IPv6 connectivity!")
 
@@ -172,7 +176,8 @@ class PorkbunDDNS():
                             self._delete_record(i['id'])
                             self._create_records(ip, record_type)
                         # Create missing A or AAAA entry
-                        if i["type"] in ["A", "AAAA"] and record_type not in [x['type'] for x in self.records if x['name'] == self.fqdn]:
+                        if i["type"] in ["A", "AAAA"] and record_type not in [x['type'] for x in self.records if
+                                                                              x['name'] == self.fqdn]:
                             logger.debug('Create missing A or AAAA entry, with:\n{}'.format(json.dumps(
                                 {"name": self.fqdn, "type": record_type, "content": str(ip.exploded)})))
                             self._create_records(ip, record_type)
@@ -202,9 +207,9 @@ class PorkbunDDNS():
                     logger.debug('Deleting existing entry:\n{}'.format(json.dumps(
                         {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
                     self._delete_record(i['id'])
-            else:
-                logger.debug('Record not found:\n{}'.format(json.dumps(
-                    {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
+                else:
+                    logger.debug('Record not found:\n{}'.format(json.dumps(
+                        {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
 
     def _delete_record(self, domain_id: str):
         """Delete a DNS record with the given domain ID.
@@ -214,7 +219,8 @@ class PorkbunDDNS():
                                    for x in self.records if x['id'] == domain_id][0]
             status = self._api("/dns/delete/" + self.domain + "/" + domain_id)
             logger.info('Deleting {}-Record for {} with content: {}, Status: {}'.format(type,
-                                                                                        name, content, status["status"]))
+                                                                                        name, content,
+                                                                                        status["status"]))
 
     def _create_records(self, ip: IPv4Address | IPv6Address, record_type: str):
         """Create DNS records for the subdomain with the given IP address and type.
@@ -222,7 +228,8 @@ class PorkbunDDNS():
 
         data = self.config.copy()
         data.update({"name": self.subdomain, "type": record_type,
-                    "content": ip.exploded, "ttl": 600})
+                     "content": ip.exploded, "ttl": 600})
         status = self._api("/dns/create/" + self.domain, data)
         logger.info('Creating {}-Record for {} with content: {}, Status: {}'.format(record_type,
-                                                                                    self.fqdn, ip.exploded, status["status"]))
+                                                                                    self.fqdn, ip.exploded,
+                                                                                    status["status"]))

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -72,7 +72,7 @@ class PorkbunDDNS:
                                     "Failed to retrieve IPv4 Address from %s! HTTP status code: %s", url, str(response.code()))
                         except URLError as err:
                             logger.warning(
-                                "Error reaching %s! Error: %s", url, repr(err))
+                                "Error reaching %s! - %s", url, err.reason)
                 if self.ipv6:
                     urls = ["https://v6.ident.me",
                             "https://api6.ipify.org",
@@ -88,7 +88,7 @@ class PorkbunDDNS:
                                     "Failed to retrieve IPv6 Address from %s! HTTP status code: %s", url, str(response.code()))
                         except URLError as err:
                             logger.warning(
-                                "Error reaching %s! Error: %s", url, repr(err))
+                                "Error reaching %s! - %s", url, err.reason)
 
             public_ips = set(public_ips)
 

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-import logging
 import json
-from ipaddress import IPv4Address, IPv6Address, ip_address
+import logging
 import urllib.request
+from ipaddress import IPv4Address, IPv6Address, ip_address
 from urllib.error import HTTPError, URLError
 
 from porkbun_ddns.config import Config
 from porkbun_ddns.helpers import get_ips_from_fritzbox
 
-logger = logging.getLogger('porkbun_ddns')
+logger = logging.getLogger("porkbun_ddns")
 
 
 class PorkbunDDNS_Error(Exception):
@@ -27,7 +27,7 @@ class PorkbunDDNS:
             public_ips: list | None = None,
             fritzbox_ip: str | None = None,
             ipv4: bool = True,
-            ipv6: bool = True
+            ipv6: bool = True,
     ) -> None:
 
         self.config = config._asdict()
@@ -38,14 +38,14 @@ class PorkbunDDNS:
         self.ipv4 = ipv4
         self.ipv6 = ipv6
         self.fqdn = self.domain
-        self.subdomain = '@'
+        self.subdomain = "@"
 
     def set_subdomain(self, subdomain: str) -> None:
         self.subdomain = subdomain.lower()
-        if self.subdomain == '@':
+        if self.subdomain == "@":
             self.fqdn = self.domain
         else:
-            self.fqdn = '.'.join([self.subdomain, self.domain])
+            self.fqdn = ".".join([self.subdomain, self.domain])
 
     def get_public_ips(self) -> list:
         """Retrieve the public IP addresses of the network.
@@ -61,27 +61,27 @@ class PorkbunDDNS:
                         get_ips_from_fritzbox(self.fritzbox_ip))
             else:
                 if self.ipv4:
-                    urls = ['https://v4.ident.me',
-                    'https://api.ipify.org',
-                    'https://ipv4.icanhazip.com']
+                    urls = ["https://v4.ident.me",
+                    "https://api.ipify.org",
+                    "https://ipv4.icanhazip.com"]
                     for url in urls:
                         try:
                             with urllib.request.urlopen(url) as response:
                                 if response.getcode() == 200:
-                                    public_ips.append(response.read().decode('utf-8'))
+                                    public_ips.append(response.read().decode("utf-8"))
                                     break
                                 logger.warning("Failed to retrieve IPv4 Address from %s! HTTP status code: %s", url, str(response.code()))
                         except URLError as err:
                             logger.warning("Error reaching %s! Error: %s", url, repr(err))
                 if self.ipv6:
-                    urls = ['https://v6.ident.me',
-                    'https://api6.ipify.org',
-                    'https://ipv6.icanhazip.com']
+                    urls = ["https://v6.ident.me",
+                    "https://api6.ipify.org",
+                    "https://ipv6.icanhazip.com"]
                     for url in urls:
                         try:
                             with urllib.request.urlopen(url) as response:
                                 if response.getcode() == 200:
-                                    public_ips.append(response.read().decode('utf-8'))
+                                    public_ips.append(response.read().decode("utf-8"))
                                     break
                                 logger.warning("Failed to retrieve IPv6 Address from %s! HTTP status code: %s", url, str(response.code()))
                         except URLError as err:
@@ -90,45 +90,43 @@ class PorkbunDDNS:
             public_ips = set(public_ips)
 
         if not public_ips:
-            raise PorkbunDDNS_Error('Failed to obtain IP Addresses!')
+            raise PorkbunDDNS_Error("Failed to obtain IP Addresses!")
 
         return [ip_address(x) for x in public_ips if not ip_address(x).is_unspecified]
 
     def _api(self, target: str, data: dict | None = None) -> dict:
         """Send an API request to a specified target.
         """
-
         data = data or self.config
-        req = urllib.request.Request(self.config['endpoint'] + target)
-        req.data = json.dumps(data).encode('utf8')
+        req = urllib.request.Request(self.config["endpoint"] + target)
+        req.data = json.dumps(data).encode("utf8")
         try:
             response = urllib.request.urlopen(req).read()
         except HTTPError as err:
             if err.code == 400:
-                raise PorkbunDDNS_Error('Invalid API Keys!')
+                raise PorkbunDDNS_Error("Invalid API Keys!")
             else:
                 raise err
-        return json.loads(response.decode('utf-8'))
+        return json.loads(response.decode("utf-8"))
 
     def get_records(self) -> dict:
         """Retrieve the DNS records for the specified domain.
         """
-
         records = self._api("/dns/retrieve/" + self.domain)
         if records["status"] == "SUCCESS":
-            return records['records']
+            return records["records"]
         else:
             raise PorkbunDDNS_Error(
-                'Failed to get records.\n' +
-                'Make sure you specified the correct domain ({}),\n'.format(self.domain) +
-                'and that API access has been enabled for this domain.'
+                "Failed to get records.\n" +
+                f"Make sure you specified the correct domain ({self.domain}),\n" +
+                "and that API access has been enabled for this domain.",
             )
 
     def update_records(self):
         """Update DNS records for the specified domain.
         """
         self.records = self.get_records()
-        domain_names = [x['name'] for x in self.records if x['type']
+        domain_names = [x["name"] for x in self.records if x["type"]
                         in ["A", "AAAA", "ALIAS", "CNAME"]]
         for ip in self.get_public_ips():
             record_type = "A" if ip.version == 4 else "AAAA"
@@ -137,30 +135,30 @@ class PorkbunDDNS:
                     if i["name"] == self.fqdn:
                         # Overwrite ALIAS and CNAME
                         if i["type"] in ["ALIAS", "CNAME"]:
-                            logger.debug('Overwrite ALIAS and CNAME, with:\n{}'.format(json.dumps(
+                            logger.debug("Overwrite ALIAS and CNAME, with:\n{}".format(json.dumps(
                                 {"name": self.fqdn, "type": record_type, "content": str(ip.exploded)})))
-                            self._delete_record(i['id'])
+                            self._delete_record(i["id"])
                             self._create_records(ip, record_type)
                         # Update existing entry
-                        if i["type"] == record_type and i['content'] != ip.exploded:
-                            logger.debug('Update existing entry, with:\n{}'.format(json.dumps(
+                        if i["type"] == record_type and i["content"] != ip.exploded:
+                            logger.debug("Update existing entry, with:\n{}".format(json.dumps(
                                 {"name": self.fqdn, "type": record_type, "content": str(ip.exploded)})))
-                            self._delete_record(i['id'])
+                            self._delete_record(i["id"])
                             self._create_records(ip, record_type)
                         # Create missing A or AAAA entry
-                        if i["type"] in ["A", "AAAA"] and record_type not in [x['type'] for x in self.records if
-                                                                              x['name'] == self.fqdn]:
-                            logger.debug('Create missing A or AAAA entry, with:\n{}'.format(json.dumps(
+                        if i["type"] in ["A", "AAAA"] and record_type not in [x["type"] for x in self.records if
+                                                                              x["name"] == self.fqdn]:
+                            logger.debug("Create missing A or AAAA entry, with:\n{}".format(json.dumps(
                                 {"name": self.fqdn, "type": record_type, "content": str(ip.exploded)})))
                             self._create_records(ip, record_type)
                             # Update records
                             self.records = self.get_records()
                         # Everything is up to date
-                        if i["type"] == record_type and i['content'] == ip.exploded:
-                            logger.info('{}-Record of {} is up to date!'.format(
+                        if i["type"] == record_type and i["content"] == ip.exploded:
+                            logger.info("{}-Record of {} is up to date!".format(
                                 i["type"], i["name"]))
             else:
-                logger.debug('Create new record, with:\n{}'.format(json.dumps(
+                logger.debug("Create new record, with:\n{}".format(json.dumps(
                     {"name": self.fqdn, "type": record_type, "content": str(ip.exploded)})))
                 # Create new record
                 self._create_records(ip, record_type)
@@ -171,37 +169,36 @@ class PorkbunDDNS:
         """Delete A and AAAA DNS record for set record.
         """
         self.records = self.get_records()
-        domain_names = [x['name'] for x in self.records if x['type']
+        domain_names = [x["name"] for x in self.records if x["type"]
                         in ["A", "AAAA"]]
         if self.fqdn in domain_names:
             for i in self.records:
-                if i["name"] == self.fqdn and i['type'] in ["A", "AAAA"]:
-                    logger.debug('Deleting existing entry:\n{}'.format(json.dumps(
-                        {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
-                    self._delete_record(i['id'])
+                if i["name"] == self.fqdn and i["type"] in ["A", "AAAA"]:
+                    logger.debug("Deleting existing entry:\n{}".format(json.dumps(
+                        {"name": self.fqdn, "type": i["type"], "content": str(i["content"])})))
+                    self._delete_record(i["id"])
                 else:
-                    logger.debug('Record not found:\n{}'.format(json.dumps(
-                        {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
+                    logger.debug("Record not found:\n{}".format(json.dumps(
+                        {"name": self.fqdn, "type": i["type"], "content": str(i["content"])})))
 
     def _delete_record(self, domain_id: str):
         """Delete a DNS record with the given domain ID.
         """
         if self.records:
-            type, name, content = [(x['type'], x['name'], x['content'])
-                                   for x in self.records if x['id'] == domain_id][0]
+            type, name, content = [(x["type"], x["name"], x["content"])
+                                   for x in self.records if x["id"] == domain_id][0]
             status = self._api("/dns/delete/" + self.domain + "/" + domain_id)
-            logger.info('Deleting {}-Record for {} with content: {}, Status: {}'.format(type,
+            logger.info("Deleting {}-Record for {} with content: {}, Status: {}".format(type,
                                                                                         name, content,
                                                                                         status["status"]))
 
     def _create_records(self, ip: IPv4Address | IPv6Address, record_type: str):
         """Create DNS records for the subdomain with the given IP address and type.
         """
-
         data = self.config.copy()
         data.update({"name": self.subdomain, "type": record_type,
                      "content": ip.exploded, "ttl": 600})
         status = self._api("/dns/create/" + self.domain, data)
-        logger.info('Creating {}-Record for {} with content: {}, Status: {}'.format(record_type,
+        logger.info("Creating {}-Record for {} with content: {}, Status: {}".format(record_type,
                                                                                     self.fqdn, ip.exploded,
                                                                                     status["status"]))

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -16,33 +16,21 @@ class PorkbunDDNS_Error(Exception):
     pass
 
 
-class PorkbunDDNS():
+class PorkbunDDNS:
     """A class for updating dynamic DNS records for a Porkbun domain.
     """
 
     def __init__(
-        self,
-        config: dict | str,
-        domain: str,
-        public_ips: list | None = None,
-        fritzbox_ip: str | None = None,
-        ipv4: bool = True,
-        ipv6: bool = True
+            self,
+            config: Config,
+            domain: str,
+            public_ips: list | None = None,
+            fritzbox_ip: str | None = None,
+            ipv4: bool = True,
+            ipv6: bool = True
     ) -> None:
-        if isinstance(config, dict):
-            self.config = config
-        else:
-            if isinstance(config, str):
-                try:
-                    self._load_config(config)
-                except FileNotFoundError as err:
-                    raise FileNotFoundError(
-                        "Config path is invalid!\nPath:\n{}".format(config)) from err
-            else:
-                raise TypeError("Invalid config! Config should be a str (filepath) or dict!\nYour config:\n{}\nType: {}".format(
-                    config, type(config)))
 
-        self._check_config()
+        self.config = config._asdict()
         self.static_ips = public_ips
         self.domain = domain.lower()
         self.records = None
@@ -51,22 +39,6 @@ class PorkbunDDNS():
         self.ipv6 = ipv6
         self.fqdn = self.domain
         self.subdomain = '@'
-
-    def _load_config(self, config: str) -> None:
-        """Load a JSON configuration file.
-        """
-        with open(config) as fid:
-            self.config = json.load(fid)
-
-    def _check_config(self) -> None:
-        """Check if the configuration is valid.
-        """
-        required_keys = ["secretapikey", "apikey"]
-        if all(x not in self.config for x in required_keys):
-            raise PorkbunDDNS_Error("Missing keys! All of the following are required: '{}'\nYour config:\n{}".format(
-                required_keys, self.config))
-        if 'endpoint' not in self.config.keys():
-            self.config["endpoint"] = "https://porkbun.com/api/json/v3"
 
     def set_subdomain(self, subdomain: str) -> None:
         self.subdomain = subdomain.lower()

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -63,7 +63,7 @@ class PorkbunDDNS:
                             "https://ipv4.icanhazip.com"]
                     for url in urls:
                         try:
-                            with urllib.request.urlopen(url) as response:
+                            with urllib.request.urlopen(url, timeout=10) as response:
                                 if response.getcode() == 200:
                                     public_ips.append(
                                         response.read().decode("utf-8"))
@@ -79,7 +79,7 @@ class PorkbunDDNS:
                             "https://ipv6.icanhazip.com"]
                     for url in urls:
                         try:
-                            with urllib.request.urlopen(url) as response:
+                            with urllib.request.urlopen(url, timeout=10) as response:
                                 if response.getcode() == 200:
                                     public_ips.append(
                                         response.read().decode("utf-8"))
@@ -104,7 +104,7 @@ class PorkbunDDNS:
         req = urllib.request.Request(self.config["endpoint"] + target)
         req.data = json.dumps(data).encode("utf8")
         try:
-            response = urllib.request.urlopen(req).read()
+            response = urllib.request.urlopen(req,  timeout=10).read()
         except HTTPError as err:
             if err.code == 400:
                 raise PorkbunDDNS_Error("Invalid API Keys!")

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -168,21 +168,21 @@ class PorkbunDDNS:
                 # Update records
                 self.records = self.get_records()
 
-    def delete_records(self):
+def delete_records(self):
         """Delete A and AAAA DNS record for set record.
         """
         self.records = self.get_records()
-        domain_names = [x["name"] for x in self.records if x["type"]
+        domain_names = [x['name'] for x in self.records if x['type']
                         in ["A", "AAAA"]]
         if self.fqdn in domain_names:
             for i in self.records:
-                if i["name"] == self.fqdn and i["type"] in ["A", "AAAA"]:
-                    logger.debug("Deleting existing entry:\n{}".format(json.dumps(
-                        {"name": self.fqdn, "type": i["type"], "content": str(i["content"])})))
-                    self._delete_record(i["id"])
-                else:
-                    logger.debug("Record not found:\n{}".format(json.dumps(
-                        {"name": self.fqdn, "type": i["type"], "content": str(i["content"])})))
+                if i["name"] == self.fqdn and i['type'] in ["A", "AAAA"]:
+                    logger.debug('Deleting existing entry:\n{}'.format(json.dumps(
+                        {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
+                    self._delete_record(i['id'])
+        else:
+            logger.debug('Record not found:\n{}'.format(json.dumps(
+                {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
 
     def _delete_record(self, domain_id: str):
         """Delete a DNS record with the given domain ID.

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -172,17 +172,17 @@ class PorkbunDDNS:
             """Delete A and AAAA DNS record for set record.
             """
             self.records = self.get_records()
-            domain_names = [x['name'] for x in self.records if x['type']
+            domain_names = [x["name"] for x in self.records if x["type"]
                             in ["A", "AAAA"]]
             if self.fqdn in domain_names:
                 for i in self.records:
-                    if i["name"] == self.fqdn and i['type'] in ["A", "AAAA"]:
-                        logger.debug('Deleting existing entry:\n{}'.format(json.dumps(
-                            {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
-                        self._delete_record(i['id'])
+                    if i["name"] == self.fqdn and i["type"] in ["A", "AAAA"]:
+                        logger.debug("Deleting existing entry:\n{}".format(json.dumps(
+                            {"name": self.fqdn, "type": i["type"], "content": str(i["content"])})))
+                        self._delete_record(i["id"])
             else:
-                logger.debug('Record not found:\n{}'.format(json.dumps(
-                    {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
+                logger.debug("Record not found:\n{}".format(json.dumps(
+                    {"name": self.fqdn, "type": i["type"], "content": str(i["content"])})))
 
     def _delete_record(self, domain_id: str):
         """Delete a DNS record with the given domain ID.

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -168,21 +168,21 @@ class PorkbunDDNS:
                 # Update records
                 self.records = self.get_records()
 
-def delete_records(self):
-        """Delete A and AAAA DNS record for set record.
-        """
-        self.records = self.get_records()
-        domain_names = [x['name'] for x in self.records if x['type']
-                        in ["A", "AAAA"]]
-        if self.fqdn in domain_names:
-            for i in self.records:
-                if i["name"] == self.fqdn and i['type'] in ["A", "AAAA"]:
-                    logger.debug('Deleting existing entry:\n{}'.format(json.dumps(
-                        {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
-                    self._delete_record(i['id'])
-        else:
-            logger.debug('Record not found:\n{}'.format(json.dumps(
-                {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
+    def delete_records(self):
+            """Delete A and AAAA DNS record for set record.
+            """
+            self.records = self.get_records()
+            domain_names = [x['name'] for x in self.records if x['type']
+                            in ["A", "AAAA"]]
+            if self.fqdn in domain_names:
+                for i in self.records:
+                    if i["name"] == self.fqdn and i['type'] in ["A", "AAAA"]:
+                        logger.debug('Deleting existing entry:\n{}'.format(json.dumps(
+                            {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
+                        self._delete_record(i['id'])
+            else:
+                logger.debug('Record not found:\n{}'.format(json.dumps(
+                    {"name": self.fqdn, "type": i['type'], "content": str(i['content'])})))
 
     def _delete_record(self, domain_id: str):
         """Delete a DNS record with the given domain ID.

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -7,13 +7,10 @@ from ipaddress import IPv4Address, IPv6Address, ip_address
 from urllib.error import HTTPError, URLError
 
 from porkbun_ddns.config import Config
+from porkbun_ddns.errors import PorkbunDDNS_Error
 from porkbun_ddns.helpers import get_ips_from_fritzbox
 
 logger = logging.getLogger("porkbun_ddns")
-
-
-class PorkbunDDNS_Error(Exception):
-    pass
 
 
 class PorkbunDDNS:
@@ -62,30 +59,36 @@ class PorkbunDDNS:
             else:
                 if self.ipv4:
                     urls = ["https://v4.ident.me",
-                    "https://api.ipify.org",
-                    "https://ipv4.icanhazip.com"]
+                            "https://api.ipify.org",
+                            "https://ipv4.icanhazip.com"]
                     for url in urls:
                         try:
                             with urllib.request.urlopen(url) as response:
                                 if response.getcode() == 200:
-                                    public_ips.append(response.read().decode("utf-8"))
+                                    public_ips.append(
+                                        response.read().decode("utf-8"))
                                     break
-                                logger.warning("Failed to retrieve IPv4 Address from %s! HTTP status code: %s", url, str(response.code()))
+                                logger.warning(
+                                    "Failed to retrieve IPv4 Address from %s! HTTP status code: %s", url, str(response.code()))
                         except URLError as err:
-                            logger.warning("Error reaching %s! Error: %s", url, repr(err))
+                            logger.warning(
+                                "Error reaching %s! Error: %s", url, repr(err))
                 if self.ipv6:
                     urls = ["https://v6.ident.me",
-                    "https://api6.ipify.org",
-                    "https://ipv6.icanhazip.com"]
+                            "https://api6.ipify.org",
+                            "https://ipv6.icanhazip.com"]
                     for url in urls:
                         try:
                             with urllib.request.urlopen(url) as response:
                                 if response.getcode() == 200:
-                                    public_ips.append(response.read().decode("utf-8"))
+                                    public_ips.append(
+                                        response.read().decode("utf-8"))
                                     break
-                                logger.warning("Failed to retrieve IPv6 Address from %s! HTTP status code: %s", url, str(response.code()))
+                                logger.warning(
+                                    "Failed to retrieve IPv6 Address from %s! HTTP status code: %s", url, str(response.code()))
                         except URLError as err:
-                            logger.warning("Error reaching %s! Error: %s", url, repr(err))
+                            logger.warning(
+                                "Error reaching %s! Error: %s", url, repr(err))
 
             public_ips = set(public_ips)
 

--- a/porkbun_ddns/test/test_config.py
+++ b/porkbun_ddns/test/test_config.py
@@ -1,0 +1,142 @@
+import argparse
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch
+
+from porkbun_ddns.config import extract_config, Config, load_config_file
+from porkbun_ddns.test.test_porkbun_ddns import valid_config
+
+
+def _mock(*names_contained: str, key_pref: str = "", val_pref: str = "") -> dict[str, str]:
+    d = valid_config._asdict()
+    if names_contained:
+        for name in names_contained:
+            if name not in d:
+                raise ValueError(f"{name} is not a config-value")
+    else:
+        names_contained = tuple(d.keys())
+    d = {key_pref + key: val_pref + value for key, value in d.items() if key in names_contained}
+    return d
+
+
+def mock_namespace(config_file: Optional[Path] = None, *names_contained: str) -> argparse.Namespace:
+    d = _mock(*names_contained, val_pref="argparse_")
+    if config_file:
+        d |= {"config": str(config_file)}
+    return argparse.Namespace(**d)
+
+
+def mock_environ(*names_contained: str) -> dict[str, str]:
+    d = _mock(*names_contained, key_pref="porkbun_", val_pref="environ_")
+    return {key.upper(): value for key, value in d.items()}
+
+
+class TestConfig(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tmpdir = None
+
+    def mock_file(self, *names_contained: str) -> Path:
+        d = _mock(*names_contained, val_pref="file_")
+        self.tmpdir = tempfile.TemporaryDirectory()
+        tmpfile = Path(self.tmpdir.name) / "porkbun-ddns-config.json"
+        with tmpfile.open(mode='w') as tf:
+            json.dump(d, tf)
+        return tmpfile
+
+    def tearDown(self) -> None:
+        if self.tmpdir:
+            self.tmpdir.cleanup()
+            self.tmpdir = None
+
+    @patch.dict(os.environ, mock_environ())
+    def test_all_argparse(self):
+        config = extract_config(mock_namespace(self.mock_file()))
+        for field in Config._fields:
+            self.assertTrue(getattr(config, field).startswith("argparse_"))
+
+    def test_all_argparse_no_env(self):
+        config = extract_config(mock_namespace(self.mock_file()))
+        for field in Config._fields:
+            self.assertTrue(getattr(config, field).startswith("argparse_"))
+
+        config = extract_config(mock_namespace())
+        for field in Config._fields:
+            self.assertTrue(getattr(config, field).startswith("argparse_"))
+
+    @patch.dict(os.environ, mock_environ())
+    def test_all_environ(self):
+        args = argparse.Namespace(config=self.mock_file())
+        config = extract_config(args)
+        for field in Config._fields:
+            self.assertTrue(getattr(config, field).startswith("environ_"))
+
+        args = argparse.Namespace()
+        config = extract_config(args)
+        for field in Config._fields:
+            self.assertTrue(getattr(config, field).startswith("environ_"))
+
+    def test_all_file(self):
+        args = argparse.Namespace(config=self.mock_file())
+        config = extract_config(args)
+        for field in Config._fields:
+            self.assertTrue(getattr(config, field).startswith("file_"))
+
+    def test_not_set(self):
+        args = argparse.Namespace()
+        with self.assertRaises(ValueError):
+            extract_config(args)
+
+        args = mock_namespace(self.mock_file("apikey"), "secretapikey")
+        with self.assertRaises(ValueError):
+            extract_config(args)
+
+    @patch.dict(os.environ, mock_environ())
+    def test_mix_argparse_environ(self):
+        args = mock_namespace(self.mock_file(), "endpoint")
+        config = extract_config(args)
+
+        self.assertTrue(config.endpoint.startswith("argparse_"))
+        self.assertTrue(config.apikey.startswith("environ_"))
+        self.assertTrue(config.secretapikey.startswith("environ_"))
+
+    def test_mix_argparse_file(self):
+        args = mock_namespace(self.mock_file(), "apikey")
+        config = extract_config(args)
+
+        self.assertTrue(config.endpoint.startswith("file_"))
+        self.assertTrue(config.apikey.startswith("argparse_"))
+        self.assertTrue(config.secretapikey.startswith("file_"))
+
+    @patch.dict(os.environ, mock_environ("secretapikey"))
+    def test_mix_environ_file(self):
+        args = argparse.Namespace(config=self.mock_file())
+        config = extract_config(args)
+
+        self.assertTrue(config.endpoint.startswith("file_"))
+        self.assertTrue(config.apikey.startswith("file_"))
+        self.assertTrue(config.secretapikey.startswith("environ_"))
+
+    def test_load_config_file(self):
+        file = self.mock_file("endpoint", "secretapikey")
+        d = load_config_file(file)
+
+        self.assertTrue(d["endpoint"].startswith("file_"))
+        self.assertTrue(d["secretapikey"].startswith("file_"))
+        self.assertFalse("apikey" in d)
+
+    def test_only_config_file(self):
+        file = self.mock_file()
+        config = extract_config(file)
+        self.assertTrue(config.endpoint.startswith("file_"))
+        self.assertTrue(config.apikey.startswith("file_"))
+        self.assertTrue(config.secretapikey.startswith("file_"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/porkbun_ddns/test/test_config.py
+++ b/porkbun_ddns/test/test_config.py
@@ -4,10 +4,9 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Optional
 from unittest.mock import patch
 
-from porkbun_ddns.config import extract_config, Config, load_config_file
+from porkbun_ddns.config import Config, extract_config, load_config_file
 from porkbun_ddns.test.test_porkbun_ddns import valid_config
 
 
@@ -23,7 +22,7 @@ def _mock(*names_contained: str, key_pref: str = "", val_pref: str = "") -> dict
     return d
 
 
-def mock_namespace(config_file: Optional[Path] = None, *names_contained: str) -> argparse.Namespace:
+def mock_namespace(config_file: Path | None = None, *names_contained: str) -> argparse.Namespace:
     d = _mock(*names_contained, val_pref="argparse_")
     if config_file:
         d |= {"config": str(config_file)}
@@ -45,7 +44,7 @@ class TestConfig(unittest.TestCase):
         d = _mock(*names_contained, val_pref="file_")
         self.tmpdir = tempfile.TemporaryDirectory()
         tmpfile = Path(self.tmpdir.name) / "porkbun-ddns-config.json"
-        with tmpfile.open(mode='w') as tf:
+        with tmpfile.open(mode="w") as tf:
             json.dump(d, tf)
         return tmpfile
 
@@ -138,5 +137,5 @@ class TestConfig(unittest.TestCase):
         self.assertTrue(config.secretapikey.startswith("file_"))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/porkbun_ddns/test/test_config.py
+++ b/porkbun_ddns/test/test_config.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from porkbun_ddns.config import Config, extract_config, load_config_file
 from porkbun_ddns.test.test_porkbun_ddns import valid_config
-
+from porkbun_ddns.errors import PorkbunDDNS_Error
 
 def _mock(*names_contained: str, key_pref: str = "", val_pref: str = "") -> dict[str, str]:
     d = valid_config._asdict()
@@ -88,11 +88,11 @@ class TestConfig(unittest.TestCase):
 
     def test_not_set(self):
         args = argparse.Namespace()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PorkbunDDNS_Error):
             extract_config(args)
 
         args = mock_namespace(self.mock_file("apikey"), "secretapikey")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PorkbunDDNS_Error):
             extract_config(args)
 
     @patch.dict(os.environ, mock_environ())

--- a/porkbun_ddns/test/test_porkbun_ddns.py
+++ b/porkbun_ddns/test/test_porkbun_ddns.py
@@ -1,16 +1,17 @@
 import unittest
 from unittest.mock import patch, MagicMock
 from ..porkbun_ddns import PorkbunDDNS, PorkbunDDNS_Error
+from ..config import Config
 import logging
 
 logger = logging.getLogger('porkbun_ddns')
 logger.setLevel(logging.INFO)
 
-
-valid_config = {"endpoint": "https://porkbun.com/api/json/v3",
-                "apikey": "pk1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-                "secretapikey": "sk1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-                }
+valid_config = Config(
+    endpoint="https://porkbun.com/api/json/v3",
+    apikey="pk1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    secretapikey="sk1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+)
 
 domain = 'my-domain.local'
 ips = ['127.0.0.1', '::1']
@@ -38,22 +39,6 @@ def mock_api(status="SUCCESS", mock_records=None):
 
 class TestPorkbunDDNS(unittest.TestCase):
     maxDiff = None
-
-    def test_check_valid_config(self):
-        porkbun_ddns = PorkbunDDNS(valid_config, domain, ips)
-        self.assertEqual(porkbun_ddns.config, valid_config)
-        valid_config_wo_endpoint = valid_config.copy()
-        valid_config_wo_endpoint.pop('endpoint')
-        porkbun_ddns = PorkbunDDNS(valid_config_wo_endpoint, domain, ips)
-        self.assertEqual(porkbun_ddns.config, valid_config)
-
-    def test_check_invalid_config(self):
-        self.assertRaises(PorkbunDDNS_Error, PorkbunDDNS,
-                          {'invalid': 000}, domain, ips)
-        self.assertRaises(FileNotFoundError, PorkbunDDNS,
-                          'invalid', domain, ips)
-        self.assertRaises(TypeError, PorkbunDDNS, None, domain, ips)
-        self.assertRaises(TypeError, PorkbunDDNS, 000, domain, ips)
 
     @patch.object(PorkbunDDNS,
                   "_api",

--- a/porkbun_ddns/test/test_porkbun_ddns.py
+++ b/porkbun_ddns/test/test_porkbun_ddns.py
@@ -1,20 +1,21 @@
-import unittest
-from unittest.mock import patch, MagicMock
-from ..porkbun_ddns import PorkbunDDNS, PorkbunDDNS_Error
-from ..config import Config
 import logging
+import unittest
+from unittest.mock import MagicMock, patch
 
-logger = logging.getLogger('porkbun_ddns')
+from ..config import Config
+from ..porkbun_ddns import PorkbunDDNS, PorkbunDDNS_Error
+
+logger = logging.getLogger("porkbun_ddns")
 logger.setLevel(logging.INFO)
 
 valid_config = Config(
     endpoint="https://porkbun.com/api/json/v3",
     apikey="pk1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    secretapikey="sk1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    secretapikey="sk1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 )
 
-domain = 'my-domain.local'
-ips = ['127.0.0.1', '::1']
+domain = "my-domain.local"
+ips = ["127.0.0.1", "::1"]
 
 
 def mock_api(status="SUCCESS", mock_records=None):
@@ -30,8 +31,8 @@ def mock_api(status="SUCCESS", mock_records=None):
                     "content": record["content"],
                     "ttl": "600",
                     "prio": "0",
-                    "notes": ""
-                }
+                    "notes": "",
+                },
             )
             mock_id += 1
     return {"status": status, "records": records}
@@ -43,7 +44,7 @@ class TestPorkbunDDNS(unittest.TestCase):
     @patch.object(PorkbunDDNS,
                   "_api",
                   return_value=mock_api(
-                      status='SUCCESS',
+                      status="SUCCESS",
                       mock_records=[
                           {
                               "name": "my-domain.local",
@@ -52,21 +53,21 @@ class TestPorkbunDDNS(unittest.TestCase):
                           {
                               "name": "my-domain.local",
                               "type": "AAAA",
-                              "content": "0000:0000:0000:0000:0000:0000:0000:0001"}
+                              "content": "0000:0000:0000:0000:0000:0000:0000:0001"},
                       ]))
     def test_record_exists_and_up_to_date(self, mocker=None):
         porkbun_ddns = PorkbunDDNS(valid_config, domain, ips)
-        with self.assertLogs('porkbun_ddns', level='INFO') as cm:
-            porkbun_ddns.set_subdomain('@')
+        with self.assertLogs("porkbun_ddns", level="INFO") as cm:
+            porkbun_ddns.set_subdomain("@")
             porkbun_ddns.update_records()
             self.assertEqual(cm.output,
-                             ['INFO:porkbun_ddns:A-Record of my-domain.local is up to date!',
-                              'INFO:porkbun_ddns:AAAA-Record of my-domain.local is up to date!'])
+                             ["INFO:porkbun_ddns:A-Record of my-domain.local is up to date!",
+                              "INFO:porkbun_ddns:AAAA-Record of my-domain.local is up to date!"])
 
     @patch.object(PorkbunDDNS,
                   "_api",
                   return_value=mock_api(
-                      status='SUCCESS',
+                      status="SUCCESS",
                       mock_records=[
                           {
                               "name": "my-domain.local",
@@ -75,76 +76,76 @@ class TestPorkbunDDNS(unittest.TestCase):
                           {
                               "name": "my-domain.local",
                               "type": "AAAA",
-                              "content": "0000:0000:0000:0000:0000:0000:0000:0002"}
+                              "content": "0000:0000:0000:0000:0000:0000:0000:0002"},
                       ]))
     def test_record_exists_and_out_dated(self, mocker=None):
         porkbun_ddns = PorkbunDDNS(valid_config, domain, ips)
-        with self.assertLogs('porkbun_ddns', level='INFO') as cm:
-            porkbun_ddns.set_subdomain('@')
+        with self.assertLogs("porkbun_ddns", level="INFO") as cm:
+            porkbun_ddns.set_subdomain("@")
             porkbun_ddns.update_records()
             self.assertEqual(cm.output,
-                             ['INFO:porkbun_ddns:Deleting A-Record for my-domain.local with content: '
-                              '127.0.0.2, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Creating A-Record for my-domain.local with content: '
-                              '127.0.0.1, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Deleting AAAA-Record for my-domain.local with content: '
-                              '0000:0000:0000:0000:0000:0000:0000:0002, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Creating AAAA-Record for my-domain.local with content: '
-                              '0000:0000:0000:0000:0000:0000:0000:0001, Status: SUCCESS'])
+                             ["INFO:porkbun_ddns:Deleting A-Record for my-domain.local with content: "
+                              "127.0.0.2, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Creating A-Record for my-domain.local with content: "
+                              "127.0.0.1, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Deleting AAAA-Record for my-domain.local with content: "
+                              "0000:0000:0000:0000:0000:0000:0000:0002, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Creating AAAA-Record for my-domain.local with content: "
+                              "0000:0000:0000:0000:0000:0000:0000:0001, Status: SUCCESS"])
 
     @patch.object(PorkbunDDNS,
                   "_api",
                   return_value=mock_api())
     def test_record_do_not_exists(self, mocker=None):
         porkbun_ddns = PorkbunDDNS(valid_config, domain, ips)
-        with self.assertLogs('porkbun_ddns', level='INFO') as cm:
-            porkbun_ddns.set_subdomain('@')
+        with self.assertLogs("porkbun_ddns", level="INFO") as cm:
+            porkbun_ddns.set_subdomain("@")
             porkbun_ddns.update_records()
             self.assertEqual(cm.output,
-                             ['INFO:porkbun_ddns:Creating A-Record for my-domain.local with content: '
-                              '127.0.0.1, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Creating AAAA-Record for my-domain.local with content: '
-                              '0000:0000:0000:0000:0000:0000:0000:0001, Status: SUCCESS'])
+                             ["INFO:porkbun_ddns:Creating A-Record for my-domain.local with content: "
+                              "127.0.0.1, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Creating AAAA-Record for my-domain.local with content: "
+                              "0000:0000:0000:0000:0000:0000:0000:0001, Status: SUCCESS"])
 
     @patch.object(PorkbunDDNS,
                   "_api",
                   return_value=mock_api(
-                      status='SUCCESS',
+                      status="SUCCESS",
                       mock_records=[
                           {
                               "name": "my-domain.local",
                               "type": "ALIAS",
-                              "content": "my-domain.lan"
+                              "content": "my-domain.lan",
                           },
                           {
                               "name": "my-domain.local",
                               "type": "CNAME",
-                              "content": "my-domain.lan"}
+                              "content": "my-domain.lan"},
                       ]))
     def test_record_overwrite_alias_and_cname(self, mocker=None):
         porkbun_ddns = PorkbunDDNS(valid_config, domain, ips)
-        with self.assertLogs('porkbun_ddns', level='INFO') as cm:
-            porkbun_ddns.set_subdomain('@')
+        with self.assertLogs("porkbun_ddns", level="INFO") as cm:
+            porkbun_ddns.set_subdomain("@")
             porkbun_ddns.update_records()
             self.assertEqual(cm.output,
-                             ['INFO:porkbun_ddns:Deleting ALIAS-Record for my-domain.local with content: '
-                              'my-domain.lan, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Creating A-Record for my-domain.local with content: '
-                              '127.0.0.1, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Deleting CNAME-Record for my-domain.local with content: '
-                              'my-domain.lan, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Creating A-Record for my-domain.local with content: '
-                              '127.0.0.1, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Deleting ALIAS-Record for my-domain.local with content: '
-                              'my-domain.lan, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Creating AAAA-Record for my-domain.local with content: '
-                              '0000:0000:0000:0000:0000:0000:0000:0001, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Deleting CNAME-Record for my-domain.local with content: '
-                              'my-domain.lan, Status: SUCCESS',
-                              'INFO:porkbun_ddns:Creating AAAA-Record for my-domain.local with content: '
-                              '0000:0000:0000:0000:0000:0000:0000:0001, Status: SUCCESS'])
+                             ["INFO:porkbun_ddns:Deleting ALIAS-Record for my-domain.local with content: "
+                              "my-domain.lan, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Creating A-Record for my-domain.local with content: "
+                              "127.0.0.1, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Deleting CNAME-Record for my-domain.local with content: "
+                              "my-domain.lan, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Creating A-Record for my-domain.local with content: "
+                              "127.0.0.1, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Deleting ALIAS-Record for my-domain.local with content: "
+                              "my-domain.lan, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Creating AAAA-Record for my-domain.local with content: "
+                              "0000:0000:0000:0000:0000:0000:0000:0001, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Deleting CNAME-Record for my-domain.local with content: "
+                              "my-domain.lan, Status: SUCCESS",
+                              "INFO:porkbun_ddns:Creating AAAA-Record for my-domain.local with content: "
+                              "0000:0000:0000:0000:0000:0000:0000:0001, Status: SUCCESS"])
 
-    @patch('urllib.request.urlopen')
+    @patch("urllib.request.urlopen")
     def test_urlopen_returns_500_ipv4(self, mock_urlopen):
         # Set up the mock to return a response with status code 500
         mock_response = MagicMock()
@@ -152,16 +153,16 @@ class TestPorkbunDDNS(unittest.TestCase):
         mock_urlopen.return_value = mock_response
 
         # Instantiate your class or call the method that uses urllib.request.urlopen()
-        porkbun_ddns = PorkbunDDNS(valid_config, domain='example.com', ipv4=True, ipv6=False)
+        porkbun_ddns = PorkbunDDNS(valid_config, domain="example.com", ipv4=True, ipv6=False)
 
         # Now when you call the method that uses urllib.request.urlopen(), it will get the mocked response
         with self.assertRaises(PorkbunDDNS_Error) as context:
             porkbun_ddns.get_public_ips()
 
         # Verify that the exception has the expected error message
-        self.assertEqual(str(context.exception), 'Failed to obtain IP Addresses!')
+        self.assertEqual(str(context.exception), "Failed to obtain IP Addresses!")
 
-    @patch('urllib.request.urlopen')
+    @patch("urllib.request.urlopen")
     def test_urlopen_returns_500_ipv6(self, mock_urlopen):
         # Set up the mock to return a response with status code 500
         mock_response = MagicMock()
@@ -169,15 +170,15 @@ class TestPorkbunDDNS(unittest.TestCase):
         mock_urlopen.return_value = mock_response
 
         # Instantiate your class or call the method that uses urllib.request.urlopen()
-        porkbun_ddns = PorkbunDDNS(valid_config, domain='example.com', ipv4=False, ipv6=True)
+        porkbun_ddns = PorkbunDDNS(valid_config, domain="example.com", ipv4=False, ipv6=True)
 
         # Now when you call the method that uses urllib.request.urlopen(), it will get the mocked response
         with self.assertRaises(PorkbunDDNS_Error) as context:
             porkbun_ddns.get_public_ips()
 
         # Verify that the exception has the expected error message
-        self.assertEqual(str(context.exception), 'Failed to obtain IP Addresses!')
+        self.assertEqual(str(context.exception), "Failed to obtain IP Addresses!")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/porkbun_ddns/test/test_porkbun_ddns.py
+++ b/porkbun_ddns/test/test_porkbun_ddns.py
@@ -2,8 +2,9 @@ import logging
 import unittest
 from unittest.mock import MagicMock, patch
 
-from ..config import Config
-from ..porkbun_ddns import PorkbunDDNS, PorkbunDDNS_Error
+from porkbun_ddns.config import Config
+from porkbun_ddns import PorkbunDDNS
+from porkbun_ddns.errors import PorkbunDDNS_Error
 
 logger = logging.getLogger("porkbun_ddns")
 logger.setLevel(logging.INFO)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+xdg-base-dirs~=6.0.1

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ except FileNotFoundError:
 setup(
     name="porkbun-ddns",
     version=environ.get('VERSION'),
+    python_requires='>3.10',
     description="A unofficial DDNS-Client for Porkbun domains",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     keywords="porkbun ddns",
     packages=["porkbun_ddns"],
-    install_requires=["xdg~=5.1"],
+    install_requires=["xdg-base-dirs~=6.0.1"],
     entry_points={
         'console_scripts': ['porkbun-ddns=porkbun_ddns.cli:main']
     },

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     ],
     keywords="porkbun ddns",
     packages=["porkbun_ddns"],
+    install_requires=["xdg~=5.1"],
     entry_points={
         'console_scripts': ['porkbun-ddns=porkbun_ddns.cli:main']
     },


### PR DESCRIPTION
The intention is to be able to set default values (via the config-file), that can be overridden (via environment-variables or via the CLI). I applied this principle to the options already present in the config-file (_endpoint_, _apikey_, _secretapikey_), but my goal is to apply this pattern to all options. Values for an option are gathered first from the CLI. If not present there, the environment-variables will be checked and lastly the program tries to read the values from the config-file.

With this style I could fill in the necessary values into the config-file once and then override them when needed. Collecting all values into one file would also make backing up and sharing those values (e.g. between multiple installations) easier.

 I tried to preserve compatibility with the old interface as best as I was able, but some use-cases might have slipped through.

I decided to follow the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) for placement of the config-file to make the file-placement-decision easier and to encourage usage of standards.

I thought it was best to remove all file-handling-responsibility from the porkbun_ddns-module, since I felt that it does not fit into the area of responsibility of that class.

I tested the code on Debian 11 with Python 3.9.

Please let me know if you have any questions.

PS: This is my first pull-request, all feedback is welcome.