### PR TITLE
Fix from getting "ValueError: '{IP}\n' does not appear to be an IPv4 or IPv6 address" error

### DIFF
--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -69,7 +69,7 @@ class PorkbunDDNS:
                             with urllib.request.urlopen(url, timeout=10) as response:
                                 if response.getcode() == 200:
                                     public_ips.append(
-                                        response.read().decode("utf-8"))
+                                        response.read().decode("utf-8")).strip()
                                     break
                                 logger.warning(
                                     "Failed to retrieve IPv4 Address from %s! HTTP status code: %s", url, str(response.code()))
@@ -85,7 +85,7 @@ class PorkbunDDNS:
                             with urllib.request.urlopen(url, timeout=10) as response:
                                 if response.getcode() == 200:
                                     public_ips.append(
-                                        response.read().decode("utf-8"))
+                                        response.read().decode("utf-8")).strip()
                                     break
                                 logger.warning(
                                     "Failed to retrieve IPv6 Address from %s! HTTP status code: %s", url, str(response.code()))


### PR DESCRIPTION
The script was not working and I was getting the error mentioned in the message.

It seemed that the IP strings the script was receiving had new line characters at their ends, strange.

Fixed by changing lines 72 and 88 in porkbun_ddns.py from "response.read().decode("utf-8"))" to "response.read().decode("utf-8")).strip()".