### PR TITLE
Remove `version` element from docker compose files

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   porkbun-ddns:
     image: "mietzen/porkbun-ddns:latest"

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ You can set up a cron job get the full path to porkbun-ddns with `which porkbun-
 # Docker compose
 
 ```yaml
-version: "3"
 services:
   porkbun-ddns:
     image: "mietzen/porkbun-ddns:latest"


### PR DESCRIPTION
`version` top-level element is now obselete. It is not interpreted by docker anymore and docker warns about the
field.This pull request fixes those warnings by simply removing the element.
