### PR TITLE
Avoid creating default config file when possible

### DIFF
--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 
 from porkbun_ddns import PorkbunDDNS
-from porkbun_ddns.config import extract_config, get_config_file_default
+from porkbun_ddns.config import extract_config, get_config_file_default, create_default_config_file
 from porkbun_ddns.errors import PorkbunDDNS_Error
 
 logger = logging.getLogger("porkbun_ddns")
@@ -23,8 +23,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument("domain", help="Domain to be updated")
 
     parser.add_argument("-c", "--config", help=f"Path to config file "
-                                               f"(default: {get_config_file_default()})",
-                        default=get_config_file_default())
+                                               f"(default: {get_config_file_default()})")
     parser.add_argument("-e", "--endpoint", help="The endpoint")
     parser.add_argument("-pk", "--apikey", help="The Porkbun-API-key")
     parser.add_argument("-sk", "--secretapikey", help="The secret API-key")
@@ -64,6 +63,9 @@ def main(argv=sys.argv[1:]):
 
         if args.env_only:
             args.config = None
+        elif args.config is None:
+            args.config = get_config_file_default()
+            create_default_config_file()
 
         if args.verbose:
             logger.setLevel(logging.DEBUG)

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -23,17 +23,17 @@ config_file_default_content: Final = \
 """
 
 def get_config_file_default() -> Path:
+    return xdg.xdg_config_home() / "porkbun-ddns-config.json"
+
+def create_default_config_file():
     if not xdg.xdg_config_home().is_dir():
         os.makedirs(xdg.xdg_config_home())
         logger.info("Generating config home: %s", xdg.xdg_config_home())
 
-    config_file_name = "porkbun-ddns-config.json"
-    config_file_path = xdg.xdg_config_home() / config_file_name
+    config_file_path = get_config_file_default()
     if not config_file_path.is_file():
         config_file_path.write_text(config_file_default_content)
         logger.info("Wrote config to: %s", config_file_path)
-    return config_file_path
-
 
 def load_config_file(config_file: Path | None) -> dict[str, str] | None:
     config = None


### PR DESCRIPTION
This edit prevents the creation of the `$XDG_CONFIG_HOME/porkbun-ddns-config.json` file unless neither `-c/--config` nor `--env_only` are specified.
The primary use-case is for running the program from outside a container environment, where creating this file is not desired.