### PR TITLE
Fixed strip calls

### DIFF
--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -69,7 +69,7 @@ class PorkbunDDNS:
                             with urllib.request.urlopen(url, timeout=10) as response:
                                 if response.getcode() == 200:
                                     public_ips.append(
-                                        response.read().decode("utf-8")).strip()
+                                        response.read().decode("utf-8").strip())
                                     break
                                 logger.warning(
                                     "Failed to retrieve IPv4 Address from %s! HTTP status code: %s", url, str(response.code()))
@@ -85,7 +85,7 @@ class PorkbunDDNS:
                             with urllib.request.urlopen(url, timeout=10) as response:
                                 if response.getcode() == 200:
                                     public_ips.append(
-                                        response.read().decode("utf-8")).strip()
+                                        response.read().decode("utf-8").strip())
                                     break
                                 logger.warning(
                                     "Failed to retrieve IPv6 Address from %s! HTTP status code: %s", url, str(response.code()))


### PR DESCRIPTION
Commit ff785124c0bfc12219388a25affe8ce779e88ad2 added whitespace stripping to the responses, but made the call on the result of `append` rather than the string. This results in an exception being thrown since the return value of `append` is None.