### PR TITLE
Migrate to api.porkbun.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can set up a cron job get the full path to porkbun-ddns with `which porkbun-
 
 ```
 {
-  "endpoint":"https://porkbun.com/api/json/v3",
+  "endpoint":"https://api.porkbun.com/api/json/v3",
   "apikey": "pk1_xxx",
   "secretapikey": "sk1_xxx"
 }

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -11,7 +11,7 @@ from porkbun_ddns.errors import PorkbunDDNS_Error
 
 logger = logging.getLogger("porkbun_ddns")
 
-DEFAULT_ENDPOINT: Final = "https://porkbun.com/api/json/v3"
+DEFAULT_ENDPOINT: Final = "https://api.porkbun.com/api/json/v3"
 
 config_file_default_content: Final = \
     f"""

--- a/porkbun_ddns/test/test_porkbun_ddns.py
+++ b/porkbun_ddns/test/test_porkbun_ddns.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("porkbun_ddns")
 logger.setLevel(logging.INFO)
 
 valid_config = Config(
-    endpoint="https://porkbun.com/api/json/v3",
+    endpoint="https://api.porkbun.com/api/json/v3",
     apikey="pk1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     secretapikey="sk1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 )


### PR DESCRIPTION
Per porkbun doc: https://porkbun.com/api/json/v3/documentation

> Please note that porkbun.com currently works and has historically been the correct hostname for our API. However, we will be migrating away from that hostname and the API will no function using it at some point in the future.