### PR TITLE
Change timeout from 10 to 30

### DIFF
--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -66,7 +66,7 @@ class PorkbunDDNS:
                             "https://ipv4.icanhazip.com"]
                     for url in urls:
                         try:
-                            with urllib.request.urlopen(url, timeout=10) as response:
+                            with urllib.request.urlopen(url, timeout=30) as response:
                                 if response.getcode() == 200:
                                     public_ips.append(
                                         response.read().decode("utf-8").strip())
@@ -82,7 +82,7 @@ class PorkbunDDNS:
                             "https://ipv6.icanhazip.com"]
                     for url in urls:
                         try:
-                            with urllib.request.urlopen(url, timeout=10) as response:
+                            with urllib.request.urlopen(url, timeout=30) as response:
                                 if response.getcode() == 200:
                                     public_ips.append(
                                         response.read().decode("utf-8").strip())
@@ -107,7 +107,7 @@ class PorkbunDDNS:
         req = urllib.request.Request(self.config["endpoint"] + target)
         req.data = json.dumps(data).encode("utf8")
         try:
-            response = urllib.request.urlopen(req,  timeout=10).read()
+            response = urllib.request.urlopen(req,  timeout=30).read()
         except HTTPError as err:
             if err.code == 400:
                 raise PorkbunDDNS_Error("Invalid API Keys!")


### PR DESCRIPTION
I had an issue with the script timing out and erroring whenever I tried to set the cron job for the script to run at any other time than every minute.

Changing this from 10 to 30 fixed the problem so custom time set for the cron job works appropriately.  I assume this is a self-hosting issue, but I imagine this might be helpful to others self-hosting anyway,