### PR TITLE
Migrate to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = ["xdg-base-dirs~=6.0.2"]
 repository = "https://github.com/mietzen/porkbun-ddns"
 
 [project.scripts]
-porkbun_ddns = "porkbun_ddns.cli:main"
+porkbun-ddns = "porkbun_ddns.cli:main"
 
 [build-system]
 requires = ["setuptools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "porkbun_ddns"
+dynamic = ["version"]
+requires-python = ">=3.11"
+description = "A unofficial DDNS-Client for Porkbun domains"
+readme = "README.md"
+authors = [{ name = "Nils Stein", email = "github.nstein@mailbox.org" }]
+license = { file = "LICENSE" }
+classifiers = [
+    'Development Status :: 4 - Beta',
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: Python :: 3',
+    "Operating System :: OS Independent",
+]
+keywords = ["porkbun", "ddns"]
+dependencies = ["xdg-base-dirs~=6.0.2"]
+
+[project.urls]
+repository = "https://github.com/mietzen/porkbun-ddns"
+
+[project.scripts]
+porkbun_ddns = "porkbun_ddns.cli:main"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["porkbun_ddns"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[metadata]
-description-file=README.md
-license_files=LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,6 @@
-import sys
 from setuptools import setup
-from os import path, environ
-
-setup_file_dir = path.abspath(path.dirname(__file__))
-
-try:
-    with open(path.join(setup_file_dir, "README.md"), encoding="utf-8") as f:
-        long_description = f.read()
-except FileNotFoundError:
-    print("README.md not found")
-    sys.exit(1)
+from os import environ
 
 setup(
-    name="porkbun-ddns",
     version=environ.get('VERSION'),
-    python_requires='>3.10',
-    description="A unofficial DDNS-Client for Porkbun domains",
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    url="https://github.com/mietzen/porkbun-ddns",
-    author="Nils Stein",
-    author_email="github.nstein@mailbox.org",
-    license="MIT",
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3',
-        "Operating System :: OS Independent",
-    ],
-    keywords="porkbun ddns",
-    packages=["porkbun_ddns"],
-    install_requires=["xdg-base-dirs~=6.0.1"],
-    entry_points={
-        'console_scripts': ['porkbun-ddns=porkbun_ddns.cli:main']
-    },
 )


### PR DESCRIPTION
This allows using [`uv`](https://github.com/astral-sh/uv) instead of pip for local development while still keeping pip compatibility.