### PR TITLE
Explicitly enable ipv6 in docker-compose.yml

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -14,9 +14,11 @@ services:
       # IPV6: "FALSE" # Set IPv6 address
       # DEBUG: "FALSE" # DEBUG LOGGING
     restart: unless-stopped
-    networks:
-      - ipv6_enabled
 
-networks:
-  ipv6_enabled:
-    enable_ipv6: true
+# # Uncomment below to let it detect ipv6 address:
+#     networks:
+#       - ipv6_enabled
+
+# networks:
+#   ipv6_enabled:
+#     enable_ipv6: true

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -14,3 +14,9 @@ services:
       # IPV6: "FALSE" # Set IPv6 address
       # DEBUG: "FALSE" # DEBUG LOGGING
     restart: unless-stopped
+    networks:
+      - ipv6_enabled
+
+networks:
+  ipv6_enabled:
+    enable_ipv6: true

--- a/README.md
+++ b/README.md
@@ -134,12 +134,15 @@ services:
       # IPV4: "TRUE" # Set IPv4 address
       # DEBUG: "FALSE" # DEBUG LOGGING
     restart: unless-stopped
-    networks:
-      - ipv6_enabled
 
-networks:
-  ipv6_enabled:
-    enable_ipv6: true
+# # Uncomment below to let it detect ipv6 address:
+#     networks:
+#       - ipv6_enabled
+
+# networks:
+#   ipv6_enabled:
+#     enable_ipv6: true
+
 ```
 
 # Docker run

--- a/README.md
+++ b/README.md
@@ -134,9 +134,13 @@ services:
       # IPV4: "TRUE" # Set IPv4 address
       # DEBUG: "FALSE" # DEBUG LOGGING
     restart: unless-stopped
-```
+    networks:
+      - ipv6_enabled
 
-You have to use `docker run` with `-e IPV6="TRUE"` if you want to use IPv6, see https://github.com/mietzen/porkbun-ddns/issues/34
+networks:
+  ipv6_enabled:
+    enable_ipv6: true
+```
 
 # Docker run
 


### PR DESCRIPTION
Closes #81 

Confirmed that a minimal configuration with only `enable_ipv6` is sufficient to ping ipv6 domains.