### PR TITLE
Require python 3.10+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "porkbun_ddns"
 dynamic = ["version"]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 description = "A unofficial DDNS-Client for Porkbun domains"
 readme = "README.md"
 authors = [{ name = "Nils Stein", email = "github.nstein@mailbox.org" }]


### PR DESCRIPTION
The previous setup.py had `>3.10` for the specifier and thus I specified `>=3.11` here (given `>` is not supported in pyproject version specifier) but it seems 3.10 is supported too given it's included in CI.