### PR TITLE
Retry transient Porkbun API failures (closes #113)

### DIFF
--- a/Docker/entrypoint.py
+++ b/Docker/entrypoint.py
@@ -32,6 +32,8 @@ config = Config(
     DEFAULT_ENDPOINT,
     os.getenv('APIKEY'),
     os.getenv('SECRETAPIKEY'),
+    retry_count=os.getenv('RETRY_COUNT', '3'),
+    retry_delay=os.getenv('RETRY_DELAY', '5'),
     webhook_url=os.getenv('WEBHOOK_URL') or '',
     webhook_template=os.getenv('WEBHOOK_TEMPLATE') or '',
     webhook_template_file=os.getenv('WEBHOOK_TEMPLATE_FILE') or '',

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -32,6 +32,10 @@ def main(argv=sys.argv[1:]):
     parser.add_argument("-e", "--endpoint", help="The endpoint")
     parser.add_argument("-pk", "--apikey", help="The Porkbun-API-key")
     parser.add_argument("-sk", "--secretapikey", help="The secret API-key")
+    parser.add_argument("--retry-count",
+                        help="Number of attempts for transient API failures")
+    parser.add_argument("--retry-delay",
+                        help="Seconds to wait between retry attempts")
 
     parser.add_argument("--webhook-url",
                         help="Webhook URL to notify when IPs change")

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -61,6 +61,12 @@ class Config(NamedTuple):
     webhook_url: str = ""
     webhook_template: str = ""
     webhook_template_file: str = ""
+    retry_count: str = "3"
+    retry_delay: str = "5"
+
+
+# Config fields that must never be sent to the Porkbun API as part of a request body.
+RETRY_FIELDS: Final = ("retry_count", "retry_delay")
 
 
 class _Config:

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import urllib.request
 from ipaddress import IPv4Address, IPv6Address, ip_address
 from urllib.error import HTTPError, URLError
 
-from porkbun_ddns.config import WEBHOOK_CONFIG_FIELDS, Config
+from porkbun_ddns.config import RETRY_FIELDS, WEBHOOK_CONFIG_FIELDS, Config
 from porkbun_ddns.errors import PorkbunDDNS_Error
 from porkbun_ddns.helpers import get_ips_from_fritzbox
 
@@ -29,6 +30,8 @@ class PorkbunDDNS:
 
         self.config = {key: value for key, value in config._asdict().items()
                        if key not in WEBHOOK_CONFIG_FIELDS}
+        self.retry_count = int(config.retry_count)
+        self.retry_delay = int(config.retry_delay)
         self.static_ips = public_ips
         self.domain = domain.lower()
         self.records = None
@@ -104,19 +107,34 @@ class PorkbunDDNS:
 
     def _api(self, target: str, data: dict | None = None) -> dict:
         """Send an API request to a specified target.
+
+        Transient failures (unreachable endpoint, timeouts, HTTP 5xx) are
+        retried up to ``retry_count`` times, waiting ``retry_delay`` seconds
+        between attempts, before a ``PorkbunDDNS_Error`` is raised.
         """
-        data = data or self.config
+        body = {key: value for key, value in (data or self.config).items()
+                if key not in RETRY_FIELDS}
         req = urllib.request.Request(self.config["endpoint"] + target)
-        req.data = json.dumps(data).encode("utf8")
-        try:
-            response = urllib.request.urlopen(req,  timeout=30).read()
-        except HTTPError as err:
-            if err.code == 400:
-                raise PorkbunDDNS_Error("Invalid API Keys!")
-            raise
-        except URLError as err:
-            raise PorkbunDDNS_Error(f"Error reaching {req.get_full_url()}! - {err.reason}")
-        return json.loads(response.decode("utf-8"))
+        req.data = json.dumps(body).encode("utf8")
+        for attempt in range(self.retry_count):
+            try:
+                response = urllib.request.urlopen(req, timeout=30).read()
+                return json.loads(response.decode("utf-8"))
+            except HTTPError as err:
+                if err.code == 400:
+                    raise PorkbunDDNS_Error("Invalid API Keys!")
+                if err.code < 500:
+                    raise
+                error_message = f"Error reaching {req.get_full_url()}! - HTTP {err.code}"
+            except URLError as err:
+                error_message = f"Error reaching {req.get_full_url()}! - {err.reason}"
+            if attempt < self.retry_count - 1:
+                logger.warning(
+                    "%s Retrying in %s seconds (attempt %s/%s).",
+                    error_message, self.retry_delay, attempt + 1, self.retry_count)
+                time.sleep(self.retry_delay)
+            else:
+                raise PorkbunDDNS_Error(error_message)
 
     def get_records(self) -> dict:
         """Retrieve the DNS records for the specified domain.

--- a/porkbun_ddns/test/test_porkbun_ddns.py
+++ b/porkbun_ddns/test/test_porkbun_ddns.py
@@ -1,7 +1,8 @@
+import json
 import logging
 import unittest
 from unittest.mock import MagicMock, patch
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 from porkbun_ddns import PorkbunDDNS
 from porkbun_ddns.config import Config
@@ -182,8 +183,9 @@ class TestPorkbunDDNS(unittest.TestCase):
         self.assertEqual(str(context.exception), "Failed to obtain IP Addresses!")
 
 
+    @patch("time.sleep")
     @patch("urllib.request.urlopen")
-    def test_api_network_unreachable(self, mock_urlopen):
+    def test_api_network_unreachable(self, mock_urlopen, mock_sleep):
         mock_urlopen.side_effect = URLError(OSError(101, "Network is unreachable"))
 
         porkbun_ddns = PorkbunDDNS(valid_config, domain, ips)
@@ -196,6 +198,120 @@ class TestPorkbunDDNS(unittest.TestCase):
             str(context.exception),
         )
         self.assertIn("Network is unreachable", str(context.exception))
+
+
+class TestApiRetry(unittest.TestCase):
+
+    def setUp(self):
+        self.porkbun_ddns = PorkbunDDNS(valid_config, domain, ips)
+        self.url = valid_config.endpoint + "/dns/retrieve/" + domain
+
+    @staticmethod
+    def _success_response():
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"status": "SUCCESS"}).encode("utf-8")
+        return mock_response
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_success_on_first_attempt(self, mock_urlopen, mock_sleep):
+        mock_urlopen.return_value = self._success_response()
+
+        result = self.porkbun_ddns._api("/dns/retrieve/" + domain)
+
+        self.assertEqual(result, {"status": "SUCCESS"})
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_success_after_retries(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            URLError(OSError(101, "Network is unreachable")),
+            URLError(OSError(101, "Network is unreachable")),
+            self._success_response(),
+        ]
+
+        with self.assertLogs("porkbun_ddns", level="WARNING") as cm:
+            result = self.porkbun_ddns._api("/dns/retrieve/" + domain)
+
+        self.assertEqual(result, {"status": "SUCCESS"})
+        self.assertEqual(mock_urlopen.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+        self.assertEqual(len(cm.output), 2)
+        self.assertTrue(all("Retrying in" in msg for msg in cm.output))
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_failure_after_all_retries(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            URLError(OSError(101, "Network is unreachable")),
+            URLError(OSError(101, "Network is unreachable")),
+            URLError(OSError(101, "Network is unreachable")),
+        ]
+
+        with self.assertRaises(PorkbunDDNS_Error) as context:
+            self.porkbun_ddns._api("/dns/retrieve/" + domain)
+
+        self.assertIn("Error reaching " + self.url + "!", str(context.exception))
+        self.assertIn("Network is unreachable", str(context.exception))
+        self.assertEqual(mock_urlopen.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_http_400_raises_without_retry(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = HTTPError(self.url, 400, "Bad Request", None, None)
+
+        with self.assertRaises(PorkbunDDNS_Error) as context:
+            self.porkbun_ddns._api("/dns/retrieve/" + domain)
+
+        self.assertEqual(str(context.exception), "Invalid API Keys!")
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_http_500_retries_then_raises(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            HTTPError(self.url, 500, "Internal Server Error", None, None),
+            HTTPError(self.url, 500, "Internal Server Error", None, None),
+            HTTPError(self.url, 500, "Internal Server Error", None, None),
+        ]
+
+        with self.assertRaises(PorkbunDDNS_Error) as context:
+            self.porkbun_ddns._api("/dns/retrieve/" + domain)
+
+        self.assertIn("HTTP 500", str(context.exception))
+        self.assertEqual(mock_urlopen.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_http_404_raises_without_retry(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = HTTPError(self.url, 404, "Not Found", None, None)
+
+        with self.assertRaises(HTTPError):
+            self.porkbun_ddns._api("/dns/retrieve/" + domain)
+
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_retry_fields_not_sent_in_request_body(self, mock_urlopen, mock_sleep):
+        mock_urlopen.return_value = self._success_response()
+
+        self.porkbun_ddns._api("/dns/retrieve/" + domain)
+
+        request = mock_urlopen.call_args[0][0]
+        body = json.loads(request.data.decode("utf-8"))
+        self.assertNotIn("retry_count", body)
+        self.assertNotIn("retry_delay", body)
+        self.assertEqual(body["endpoint"], valid_config.endpoint)
+        self.assertEqual(body["apikey"], valid_config.apikey)
+        self.assertEqual(body["secretapikey"], valid_config.secretapikey)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #113

## Summary
Adds a retry mechanism for transient Porkbun API failures (network errors, timeouts, HTTP 5xx) in the shared `_api()` choke point. HTTP 4xx (except retryable 5xx handling) raises immediately, as those are permanent errors.

## Changes
- `porkbun_ddns/config.py`: new `Config` fields `retry_count` (default `"3"`) and `retry_delay` (default `"5"`); `RETRY_FIELDS` marks fields that must never be sent in the Porkbun API request body
- `porkbun_ddns/porkbun_ddns.py`: `_api()` retries URLError/timeouts and HTTP 5xx up to `retry_count` attempts, warning per attempt; HTTP 400 and other 4xx raise immediately
- `porkbun_ddns/cli.py`: `--retry-count` / `--retry-delay` flags
- `Docker/entrypoint.py`: `RETRY_COUNT` / `RETRY_DELAY` env vars (bare, no `PORKBUN_` prefix, matching existing convention)
- Config precedence unchanged: CLI args > env (`PORKBUN_RETRY_*`) > config file

## Verification
- 24 tests pass (7 new retry tests)
- `ruff check --ignore=E501 --exclude=__init__.py ./porkbun_ddns` clean
- API request body unchanged (retry fields excluded)

## Acceptance criteria
- [x] Retries transient failures with configurable count/delay
- [x] Non-retryable errors (HTTP 400) fail fast
- [x] Warns per retry attempt, never crashes
- [x] Configurable via CLI, env, and config file