### PR TITLE
Configurable log verbosity via LOG_LEVEL (closes #136)

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       # IPV4: "TRUE" # Set IPv4 address
       # IPV6: "FALSE" # Set IPv6 address
       # DEBUG: "FALSE" # DEBUG LOGGING
+      # LOG_LEVEL: "WARNING" # Set log verbosity (DEBUG, INFO, WARNING, ERROR, CRITICAL)
       # WEBHOOK_URL: "https://hooks.slack.com/services/..." # POST an IP-change notification to this URL (Slack, MS Teams, Mattermost, Google Chat compatible by default)
       # WEBHOOK_TEMPLATE: '{"text": "IP changed: {{ old_ips | join(", ") }} -> {{ new_ips | join(", ") }} ({{ domain }})"}' # Optional custom Jinja2 template
       # WEBHOOK_TEMPLATE_FILE: "/path/to/template.j2" # Optional Jinja2 template file (takes precedence over WEBHOOK_TEMPLATE)

--- a/Docker/entrypoint.py
+++ b/Docker/entrypoint.py
@@ -4,10 +4,14 @@ import logging
 from time import sleep
 from porkbun_ddns import PorkbunDDNS
 from porkbun_ddns.config import Config, DEFAULT_ENDPOINT
+from porkbun_ddns.helpers import parse_log_level
 from porkbun_ddns.webhook import fire_webhook
 
 logger = logging.getLogger('porkbun_ddns')
-if os.getenv('DEBUG', 'False').lower() in ('true', '1', 't'):
+log_level = os.getenv('LOG_LEVEL', None)
+if log_level:
+    logger.setLevel(parse_log_level(log_level))
+elif os.getenv('DEBUG', 'False').lower() in ('true', '1', 't'):
     logger.setLevel(logging.DEBUG)
 else:
     logger.setLevel(logging.INFO)

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -10,6 +10,7 @@ from porkbun_ddns.config import (
     get_config_file_default,
 )
 from porkbun_ddns.errors import PorkbunDDNS_Error
+from porkbun_ddns.helpers import parse_log_level
 from porkbun_ddns.webhook import fire_webhook
 
 logger = logging.getLogger("porkbun_ddns")
@@ -44,6 +45,10 @@ def main(argv=sys.argv[1:]):
     parser.add_argument("--webhook-template-file",
                         help="Path to a file containing the Jinja2 webhook "
                              "template (takes precedence over --webhook-template)")
+
+    parser.add_argument("--log-level",
+                        help="Set log verbosity "
+                             "(DEBUG, INFO, WARNING, ERROR, CRITICAL)")
 
     subdomains = parser.add_mutually_exclusive_group()
     subdomains.add_argument("subdomains", nargs="*",
@@ -84,7 +89,11 @@ def main(argv=sys.argv[1:]):
             args.config = get_config_file_default()
             create_default_config_file()
 
-        if args.verbose:
+        if args.log_level:
+            logger.setLevel(parse_log_level(args.log_level))
+            for handler in logger.handlers:
+                handler.setLevel(logger.level)
+        elif args.verbose:
             logger.setLevel(logging.DEBUG)
             for handler in logger.handlers:
                 handler.setLevel(logging.DEBUG)

--- a/porkbun_ddns/helpers.py
+++ b/porkbun_ddns/helpers.py
@@ -1,5 +1,50 @@
+import logging
 import urllib.request
 import xml.etree.ElementTree as ET
+
+
+def parse_log_level(level: str | None, *, default: int = logging.INFO) -> int:
+    """Parses a logging level name to its ``logging`` level integer.
+
+    Accepts the standard level names (case-insensitive): ``DEBUG``, ``INFO``,
+    ``WARNING`` (or ``WARN``), ``ERROR`` and ``CRITICAL``. Unknown or empty
+    values log a warning on the ``porkbun_ddns`` logger and fall back to
+    ``default`` (INFO).
+
+    Args:
+    ----
+        level (str | None): The level name to parse, or None.
+        default (int): The level to fall back to on unknown values.
+
+    Returns:
+    -------
+        int: The matching ``logging`` level.
+    """
+
+    if not level:
+        return default
+
+    normalized = level.strip().upper()
+    if not normalized:
+        return default
+
+    level_map = {
+        "DEBUG": logging.DEBUG,
+        "INFO": logging.INFO,
+        "WARNING": logging.WARNING,
+        "WARN": logging.WARNING,
+        "ERROR": logging.ERROR,
+        "CRITICAL": logging.CRITICAL,
+    }
+    if normalized in level_map:
+        return level_map[normalized]
+
+    logging.getLogger("porkbun_ddns").warning(
+        "Unknown log level '%s', falling back to %s",
+        level,
+        logging.getLevelName(default),
+    )
+    return default
 
 
 def get_ips_from_fritzbox(fritzbox_ip, ip_version=4):

--- a/porkbun_ddns/test/test_log_level.py
+++ b/porkbun_ddns/test/test_log_level.py
@@ -1,0 +1,89 @@
+import logging
+import unittest
+from unittest.mock import MagicMock, patch
+
+from porkbun_ddns import cli
+from porkbun_ddns.helpers import parse_log_level
+from porkbun_ddns.test.test_porkbun_ddns import valid_config
+
+logger = logging.getLogger("porkbun_ddns")
+
+
+class TestParseLogLevel(unittest.TestCase):
+
+    def test_valid_levels_case_insensitive(self):
+        cases = {
+            "DEBUG": logging.DEBUG,
+            "debug": logging.DEBUG,
+            "DeBuG": logging.DEBUG,
+            "INFO": logging.INFO,
+            "info": logging.INFO,
+            "WARNING": logging.WARNING,
+            "warning": logging.WARNING,
+            "WARN": logging.WARNING,
+            "warn": logging.WARNING,
+            "ERROR": logging.ERROR,
+            "error": logging.ERROR,
+            "CRITICAL": logging.CRITICAL,
+            "critical": logging.CRITICAL,
+        }
+        for level, expected in cases.items():
+            with self.subTest(level=level):
+                self.assertEqual(parse_log_level(level), expected)
+
+    def test_none_and_empty_default_to_info(self):
+        self.assertEqual(parse_log_level(None), logging.INFO)
+        self.assertEqual(parse_log_level(""), logging.INFO)
+
+    def test_invalid_level_logs_warning_and_falls_back_to_info(self):
+        with self.assertLogs("porkbun_ddns", level="WARNING") as captured:
+            result = parse_log_level("not_a_level")
+        self.assertEqual(result, logging.INFO)
+        self.assertIn("not_a_level", captured.output[0])
+
+    def test_invalid_level_falls_back_to_custom_default(self):
+        with self.assertLogs("porkbun_ddns", level="WARNING"):
+            result = parse_log_level("bogus", default=logging.DEBUG)
+        self.assertEqual(result, logging.DEBUG)
+
+
+class TestCliLogLevel(unittest.TestCase):
+
+    def tearDown(self):
+        logger.setLevel(logging.INFO)
+        for handler in logger.handlers:
+            handler.setLevel(logging.INFO)
+
+    @staticmethod
+    def _patch_run():
+        # keep cli.main hermetic: no config-file writes, no network
+        return patch.multiple(
+            "porkbun_ddns.cli",
+            extract_config=MagicMock(return_value=valid_config),
+            create_default_config_file=MagicMock(),
+            PorkbunDDNS=MagicMock(),
+        )
+
+    def test_log_level_warning_sets_logger(self):
+        with self._patch_run():
+            cli.main(["example.com", "--log-level", "WARNING"])
+        self.assertEqual(logger.level, logging.WARNING)
+
+    def test_log_level_wins_over_verbose(self):
+        with self._patch_run():
+            cli.main(["example.com", "--log-level", "WARNING", "--verbose"])
+        self.assertEqual(logger.level, logging.WARNING)
+
+    def test_verbose_without_log_level_sets_debug(self):
+        with self._patch_run():
+            cli.main(["example.com", "--verbose"])
+        self.assertEqual(logger.level, logging.DEBUG)
+
+    def test_no_log_level_or_verbose_keeps_info(self):
+        with self._patch_run():
+            cli.main(["example.com"])
+        self.assertEqual(logger.level, logging.INFO)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #136

## Summary
Makes log verbosity configurable so users can run at WARN/ERROR-only (reduces writes on Raspberry Pi SD cards). Adds a `LOG_LEVEL` env var for Docker and `--log-level` for the CLI, with `LOG_LEVEL` taking precedence over the legacy `DEBUG` / `--verbose` flags.

## Changes
- `porkbun_ddns/helpers.py`: new `parse_log_level()` helper — case-insensitive parsing of standard `logging` level names (`DEBUG`, `INFO`, `WARNING`/`WARN`, `ERROR`, `CRITICAL`); unknown values log a warning and fall back to INFO (never crashes)
- `porkbun_ddns/cli.py`: `--log-level` argument applied before the run loop; wins over `--verbose` when both are set
- `Docker/entrypoint.py`: `LOG_LEVEL` env var; wins over the legacy `DEBUG` env when both are set
- `Docker/docker-compose.yml`: documents the new `LOG_LEVEL` variable

## Verification
- 25 tests pass (8 new log-level tests covering each level, invalid-value fallback, and CLI precedence)
- `ruff check --ignore=E501 --exclude=__init__.py ./porkbun_ddns` clean

## Acceptance criteria
- [x] Docker: `LOG_LEVEL=WARNING` produces only WARN+ output
- [x] CLI: `--log-level WARNING` produces only WARN+ output
- [x] Invalid `LOG_LEVEL` logs a warning and falls back to INFO
- [x] Default behavior unchanged (INFO)
- [x] `LOG_LEVEL` wins over legacy `DEBUG=true` / `--verbose`
- [x] `docker-compose.yml` documents `LOG_LEVEL`
- [x] Unit tests cover each level and the invalid fallback