### PR TITLE
Jinja-templated webhook notification on IP change (closes #116)

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,7 +7,7 @@ COPY . /tmp/porkbun-ddns
 RUN cd /tmp/porkbun-ddns \
     && mv ./Docker/entrypoint.py /entrypoint.py \
     && export VERSION=${PORKBUN_DDNS_VERSION} \
-    && pip install setuptools xdg-base-dirs \
+    && pip install setuptools xdg-base-dirs jinja2 \
     && python setup.py install \
     && rm -rf /tmp/porkbun-ddns
 

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       # IPV4: "TRUE" # Set IPv4 address
       # IPV6: "FALSE" # Set IPv6 address
       # DEBUG: "FALSE" # DEBUG LOGGING
+      # WEBHOOK_URL: "https://hooks.slack.com/services/..." # POST an IP-change notification to this URL (Slack, MS Teams, Mattermost, Google Chat compatible by default)
+      # WEBHOOK_TEMPLATE: '{"text": "IP changed: {{ old_ips | join(", ") }} -> {{ new_ips | join(", ") }} ({{ domain }})"}' # Optional custom Jinja2 template
+      # WEBHOOK_TEMPLATE_FILE: "/path/to/template.j2" # Optional Jinja2 template file (takes precedence over WEBHOOK_TEMPLATE)
     restart: unless-stopped
 
 # # Uncomment below to let it detect ipv6 address:

--- a/Docker/entrypoint.py
+++ b/Docker/entrypoint.py
@@ -4,6 +4,7 @@ import logging
 from time import sleep
 from porkbun_ddns import PorkbunDDNS
 from porkbun_ddns.config import Config, DEFAULT_ENDPOINT
+from porkbun_ddns.webhook import fire_webhook
 
 logger = logging.getLogger('porkbun_ddns')
 if os.getenv('DEBUG', 'False').lower() in ('true', '1', 't'):
@@ -27,7 +28,14 @@ if os.getenv('PUBLIC_IPS', None):
     public_ips = [x.strip() for x in os.getenv('PUBLIC_IPS', None).split(',')]
 fritzbox = os.getenv('FRITZBOX', None)
 
-config = Config(DEFAULT_ENDPOINT, os.getenv('APIKEY'), os.getenv('SECRETAPIKEY'))
+config = Config(
+    DEFAULT_ENDPOINT,
+    os.getenv('APIKEY'),
+    os.getenv('SECRETAPIKEY'),
+    webhook_url=os.getenv('WEBHOOK_URL') or '',
+    webhook_template=os.getenv('WEBHOOK_TEMPLATE') or '',
+    webhook_template_file=os.getenv('WEBHOOK_TEMPLATE_FILE') or '',
+)
 
 ipv4 = ipv6 = False
 if os.getenv('IPV4', 'True').lower() in ('true', '1', 't'):
@@ -54,5 +62,8 @@ while True:
             porkbun_ddns.update_records()
     else:
         porkbun_ddns.update_records()
+    if porkbun_ddns.changes:
+        fire_webhook(config, porkbun_ddns.changes, porkbun_ddns.domain)
+        porkbun_ddns.changes = []
     logger.info('Sleeping... {}s'.format(sleep_time))
     sleep(sleep_time)

--- a/porkbun_ddns/cli.py
+++ b/porkbun_ddns/cli.py
@@ -10,6 +10,7 @@ from porkbun_ddns.config import (
     get_config_file_default,
 )
 from porkbun_ddns.errors import PorkbunDDNS_Error
+from porkbun_ddns.webhook import fire_webhook
 
 logger = logging.getLogger("porkbun_ddns")
 logger.setLevel(logging.INFO)
@@ -31,6 +32,14 @@ def main(argv=sys.argv[1:]):
     parser.add_argument("-e", "--endpoint", help="The endpoint")
     parser.add_argument("-pk", "--apikey", help="The Porkbun-API-key")
     parser.add_argument("-sk", "--secretapikey", help="The secret API-key")
+
+    parser.add_argument("--webhook-url",
+                        help="Webhook URL to notify when IPs change")
+    parser.add_argument("--webhook-template",
+                        help="Jinja2 template for the webhook payload")
+    parser.add_argument("--webhook-template-file",
+                        help="Path to a file containing the Jinja2 webhook "
+                             "template (takes precedence over --webhook-template)")
 
     subdomains = parser.add_mutually_exclusive_group()
     subdomains.add_argument("subdomains", nargs="*",
@@ -91,6 +100,9 @@ def main(argv=sys.argv[1:]):
                 porkbun_ddns.update_records()
         else:
             porkbun_ddns.update_records()
+        if porkbun_ddns.changes:
+            fire_webhook(config, porkbun_ddns.changes, porkbun_ddns.domain)
+            porkbun_ddns.changes = []
     except PorkbunDDNS_Error as e:
         logger.error("Error: " + str(e))
         sys.exit(1)

--- a/porkbun_ddns/config.py
+++ b/porkbun_ddns/config.py
@@ -13,6 +13,10 @@ logger = logging.getLogger("porkbun_ddns")
 
 DEFAULT_ENDPOINT: Final = "https://api.porkbun.com/api/json/v3"
 
+#: Config fields that are used for webhook delivery only and must never be
+#: sent to the Porkbun API as part of a request body.
+WEBHOOK_CONFIG_FIELDS: Final = ("webhook_url", "webhook_template", "webhook_template_file")
+
 config_file_default_content: Final = \
     f"""
 {{
@@ -54,6 +58,9 @@ class Config(NamedTuple):
     endpoint: str
     apikey: str
     secretapikey: str
+    webhook_url: str = ""
+    webhook_template: str = ""
+    webhook_template_file: str = ""
 
 
 class _Config:
@@ -85,6 +92,8 @@ class _Config:
             return str(param)
         if self.config_file_content and (param := self.config_file_content.get(option_name, None)):
             return str(param)
+        if option_name in Config._field_defaults:
+            return Config._field_defaults[option_name]
         raise PorkbunDDNS_Error(
             f"'{option_name}' is not defined via CLI-arguments,"
             f" as an environment-variable"

--- a/porkbun_ddns/porkbun_ddns.py
+++ b/porkbun_ddns/porkbun_ddns.py
@@ -6,7 +6,7 @@ import urllib.request
 from ipaddress import IPv4Address, IPv6Address, ip_address
 from urllib.error import HTTPError, URLError
 
-from porkbun_ddns.config import Config
+from porkbun_ddns.config import WEBHOOK_CONFIG_FIELDS, Config
 from porkbun_ddns.errors import PorkbunDDNS_Error
 from porkbun_ddns.helpers import get_ips_from_fritzbox
 
@@ -27,7 +27,8 @@ class PorkbunDDNS:
             ipv6: bool = True,
     ) -> None:
 
-        self.config = config._asdict()
+        self.config = {key: value for key, value in config._asdict().items()
+                       if key not in WEBHOOK_CONFIG_FIELDS}
         self.static_ips = public_ips
         self.domain = domain.lower()
         self.records = None
@@ -36,6 +37,7 @@ class PorkbunDDNS:
         self.ipv6 = ipv6
         self.fqdn = self.domain
         self.subdomain = "@"
+        self.changes: list = []
 
     def set_subdomain(self, subdomain: str) -> None:
         self.subdomain = subdomain.lower()
@@ -146,18 +148,21 @@ class PorkbunDDNS:
                                 {"name": self.fqdn, "type": record_type, "content": str(ip.exploded)})))
                             self._delete_record(i["id"])
                             self._create_records(ip, record_type)
+                            self._record_change(record_type, i["content"], ip.exploded)
                         # Update existing entry
                         if i["type"] == record_type and i["content"] != ip.exploded:
                             logger.debug("Update existing entry, with:\n{}".format(json.dumps(
                                 {"name": self.fqdn, "type": record_type, "content": str(ip.exploded)})))
                             self._delete_record(i["id"])
                             self._create_records(ip, record_type)
+                            self._record_change(record_type, i["content"], ip.exploded)
                         # Create missing A or AAAA entry
                         if i["type"] in ["A", "AAAA"] and record_type not in [x["type"] for x in self.records if
                                                                               x["name"] == self.fqdn]:
                             logger.debug("Create missing A or AAAA entry, with:\n{}".format(json.dumps(
                                 {"name": self.fqdn, "type": record_type, "content": str(ip.exploded)})))
                             self._create_records(ip, record_type)
+                            self._record_change(record_type, None, ip.exploded)
                             # Update records
                             self.records = self.get_records()
                         # Everything is up to date
@@ -169,8 +174,19 @@ class PorkbunDDNS:
                     {"name": self.fqdn, "type": record_type, "content": str(ip.exploded)})))
                 # Create new record
                 self._create_records(ip, record_type)
+                self._record_change(record_type, None, ip.exploded)
                 # Update records
                 self.records = self.get_records()
+
+    def _record_change(self, record_type: str, old_ip: str | None, new_ip: str) -> None:
+        """Record a DNS change for the aggregated webhook changelog.
+        """
+        self.changes.append({
+            "record_type": record_type,
+            "fqdn": self.fqdn,
+            "old_ip": old_ip,
+            "new_ip": new_ip,
+        })
 
     def delete_records(self):
             """Delete A and AAAA DNS record for set record.

--- a/porkbun_ddns/test/test_webhook.py
+++ b/porkbun_ddns/test/test_webhook.py
@@ -1,0 +1,241 @@
+import json
+import logging
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib.error import URLError
+
+from porkbun_ddns import PorkbunDDNS
+from porkbun_ddns.config import Config
+from porkbun_ddns.test.test_porkbun_ddns import domain, ips, mock_api, valid_config
+from porkbun_ddns.webhook import (
+    DEFAULT_WEBHOOK_TEMPLATE,
+    fire_webhook,
+    render_webhook_payload,
+)
+
+logger = logging.getLogger("porkbun_ddns")
+logger.setLevel(logging.INFO)
+
+webhook_config = Config(
+    endpoint=valid_config.endpoint,
+    apikey=valid_config.apikey,
+    secretapikey=valid_config.secretapikey,
+    webhook_url="https://hooks.example.com/webhook",
+)
+
+change = {"record_type": "A", "fqdn": domain, "old_ip": "127.0.0.2", "new_ip": "127.0.0.1"}
+
+
+def mock_ok_response(status=200):
+    mock_response = MagicMock()
+    mock_response.getcode.return_value = status
+    mock_response.__enter__.return_value = mock_response
+    return mock_response
+
+
+class TestWebhookFiring(unittest.TestCase):
+    maxDiff = None
+
+    @patch.object(PorkbunDDNS,
+                  "_api",
+                  return_value=mock_api(
+                      status="SUCCESS",
+                      mock_records=[
+                          {
+                              "name": domain,
+                              "type": "A",
+                              "content": "127.0.0.2"},
+                          {
+                              "name": domain,
+                              "type": "AAAA",
+                              "content": "0000:0000:0000:0000:0000:0000:0000:0002"},
+                      ]))
+    @patch("urllib.request.urlopen")
+    def test_fires_on_change(self, mock_urlopen, mocker=None):
+        mock_urlopen.return_value = mock_ok_response()
+
+        porkbun_ddns = PorkbunDDNS(webhook_config, domain, ips)
+        porkbun_ddns.set_subdomain("@")
+        porkbun_ddns.update_records()
+
+        self.assertEqual(len(porkbun_ddns.changes), 2)
+        self.assertTrue(fire_webhook(
+            webhook_config, porkbun_ddns.changes, porkbun_ddns.domain))
+        mock_urlopen.assert_called_once()
+
+        request = mock_urlopen.call_args.args[0]
+        self.assertEqual(request.method, "POST")
+        self.assertEqual(request.headers["Content-type"], "application/json")
+        self.assertEqual(mock_urlopen.call_args.kwargs["timeout"], 10)
+        payload = json.loads(request.data.decode("utf-8"))
+        self.assertIn("text", payload)
+        self.assertIn("127.0.0.2", payload["text"])
+        self.assertIn("127.0.0.1", payload["text"])
+
+    @patch.object(PorkbunDDNS,
+                  "_api",
+                  return_value=mock_api(
+                      status="SUCCESS",
+                      mock_records=[
+                          {
+                              "name": domain,
+                              "type": "A",
+                              "content": "127.0.0.1"},
+                          {
+                              "name": domain,
+                              "type": "AAAA",
+                              "content": "0000:0000:0000:0000:0000:0000:0000:0001"},
+                      ]))
+    @patch("urllib.request.urlopen")
+    def test_does_not_fire_when_up_to_date(self, mock_urlopen, mocker=None):
+        mock_urlopen.return_value = mock_ok_response()
+
+        porkbun_ddns = PorkbunDDNS(webhook_config, domain, ips)
+        porkbun_ddns.set_subdomain("@")
+        porkbun_ddns.update_records()
+
+        self.assertEqual(porkbun_ddns.changes, [])
+        self.assertFalse(fire_webhook(
+            webhook_config, porkbun_ddns.changes, porkbun_ddns.domain))
+        mock_urlopen.assert_not_called()
+
+    @patch("urllib.request.urlopen")
+    def test_does_not_fire_without_url(self, mock_urlopen):
+        self.assertFalse(fire_webhook(valid_config, [change], domain))
+        mock_urlopen.assert_not_called()
+
+    @patch("urllib.request.urlopen")
+    def test_does_not_fire_without_changes(self, mock_urlopen):
+        self.assertFalse(fire_webhook(webhook_config, [], domain))
+        mock_urlopen.assert_not_called()
+
+    @patch.object(PorkbunDDNS,
+                  "_api",
+                  side_effect=[mock_api()] * 6)
+    @patch("urllib.request.urlopen")
+    def test_aggregates_across_subdomains(self, mock_urlopen, mocker=None):
+        mock_urlopen.return_value = mock_ok_response()
+        config = Config(
+            endpoint=valid_config.endpoint,
+            apikey=valid_config.apikey,
+            secretapikey=valid_config.secretapikey,
+            webhook_url="https://hooks.example.com/webhook",
+            webhook_template='{"text": "{{ changes | length }} changes for {{ domain }}"}',
+        )
+
+        porkbun_ddns = PorkbunDDNS(config, domain, ["127.0.0.1"])
+        for subdomain in ["www", "api"]:
+            porkbun_ddns.set_subdomain(subdomain)
+            porkbun_ddns.update_records()
+
+        self.assertEqual(len(porkbun_ddns.changes), 2)
+        self.assertTrue(fire_webhook(config, porkbun_ddns.changes, porkbun_ddns.domain))
+        mock_urlopen.assert_called_once()
+
+        request = mock_urlopen.call_args.args[0]
+        payload = json.loads(request.data.decode("utf-8"))
+        self.assertEqual(payload["text"], "2 changes for my-domain.local")
+
+    @patch("urllib.request.urlopen")
+    def test_failure_does_not_crash(self, mock_urlopen):
+        mock_urlopen.side_effect = URLError(OSError(101, "Network is unreachable"))
+        with self.assertLogs("porkbun_ddns", level="WARNING"):
+            self.assertTrue(fire_webhook(webhook_config, [change], domain))
+        mock_urlopen.assert_called_once()
+
+    @patch("urllib.request.urlopen")
+    def test_timeout_does_not_crash(self, mock_urlopen):
+        mock_urlopen.side_effect = TimeoutError("timed out")
+        with self.assertLogs("porkbun_ddns", level="WARNING"):
+            self.assertTrue(fire_webhook(webhook_config, [change], domain))
+
+    @patch("urllib.request.urlopen")
+    def test_non_2xx_logs_warning(self, mock_urlopen):
+        mock_urlopen.return_value = mock_ok_response(status=500)
+        with self.assertLogs("porkbun_ddns", level="WARNING"):
+            self.assertTrue(fire_webhook(webhook_config, [change], domain))
+
+    def test_webhook_fields_excluded_from_api_payload(self):
+        porkbun_ddns = PorkbunDDNS(webhook_config, domain, ips)
+        self.assertNotIn("webhook_url", porkbun_ddns.config)
+        self.assertNotIn("webhook_template", porkbun_ddns.config)
+        self.assertNotIn("webhook_template_file", porkbun_ddns.config)
+
+
+class TestWebhookRendering(unittest.TestCase):
+    maxDiff = None
+
+    def test_default_template_renders_valid_json(self):
+        payload = render_webhook_payload([change], domain)
+        parsed = json.loads(payload)
+        self.assertIn("text", parsed)
+        self.assertIn("127.0.0.2", parsed["text"])
+        self.assertIn("127.0.0.1", parsed["text"])
+        self.assertIn(domain, parsed["text"])
+
+    def test_default_template_renders_with_empty_old_ips(self):
+        payload = render_webhook_payload(
+            [{"record_type": "A", "fqdn": domain, "old_ip": None, "new_ip": "127.0.0.1"}],
+            domain,
+        )
+        parsed = json.loads(payload)
+        self.assertIn("127.0.0.1", parsed["text"])
+
+    def test_inline_template_takes_precedence_over_default(self):
+        payload = render_webhook_payload(
+            [change], domain, template='{"from": "inline"}')
+        self.assertEqual(json.loads(payload), {"from": "inline"})
+
+    def test_file_template_takes_precedence_over_inline(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            template_file = Path(tmpdir) / "template.j2"
+            template_file.write_text('{"from": "file"}')
+            payload = render_webhook_payload(
+                [change],
+                domain,
+                template='{"from": "inline"}',
+                template_file=str(template_file),
+            )
+        self.assertEqual(json.loads(payload), {"from": "file"})
+
+    def test_missing_file_falls_back_to_inline(self):
+        with self.assertLogs("porkbun_ddns", level="WARNING"):
+            payload = render_webhook_payload(
+                [change],
+                domain,
+                template='{"from": "inline"}',
+                template_file="/nonexistent/template.j2",
+            )
+        self.assertEqual(json.loads(payload), {"from": "inline"})
+
+    def test_missing_file_falls_back_to_default(self):
+        with self.assertLogs("porkbun_ddns", level="WARNING"):
+            payload = render_webhook_payload(
+                [change], domain, template_file="/nonexistent/template.j2")
+        self.assertEqual(json.loads(payload), json.loads(
+            render_webhook_payload([change], domain, template=DEFAULT_WEBHOOK_TEMPLATE)))
+
+    def test_invalid_template_falls_back_to_default(self):
+        with self.assertLogs("porkbun_ddns", level="WARNING"):
+            payload = render_webhook_payload(
+                [change], domain, template="{{ old_ips | join(")
+        self.assertEqual(json.loads(payload), json.loads(
+            render_webhook_payload([change], domain, template=DEFAULT_WEBHOOK_TEMPLATE)))
+
+    def test_context_has_unique_ips_and_timestamp(self):
+        changes = [
+            {"record_type": "A", "fqdn": domain, "old_ip": "127.0.0.2", "new_ip": "127.0.0.1"},
+            {"record_type": "AAAA", "fqdn": domain, "old_ip": "127.0.0.2", "new_ip": "2001:db8::1"},
+        ]
+        payload = render_webhook_payload(changes, domain, template='{{ changes | length }}|{{ old_ips | length }}|{{ new_ips | length }}|{{ timestamp }}')
+        count, old_count, new_count, timestamp = payload.split("|")
+        self.assertEqual(count, "2")
+        self.assertEqual(old_count, "1")
+        self.assertEqual(new_count, "2")
+        self.assertTrue(timestamp.endswith(("+00:00", "Z")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/porkbun_ddns/webhook.py
+++ b/porkbun_ddns/webhook.py
@@ -12,7 +12,8 @@ from typing import Any
 try:  # datetime.UTC is Python 3.11+; keep 3.10 support
     from datetime import UTC
 except ImportError:  # pragma: no cover - 3.10 fallback
-    from datetime import timezone as UTC
+    from datetime import timedelta, timezone
+    UTC = timezone(timedelta(0))
 
 import jinja2
 

--- a/porkbun_ddns/webhook.py
+++ b/porkbun_ddns/webhook.py
@@ -1,0 +1,112 @@
+"""Jinja-templated webhook delivery, fired once per update pass on IP change."""
+
+from __future__ import annotations
+
+import logging
+import urllib.request
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import jinja2
+
+from porkbun_ddns.config import Config
+
+logger = logging.getLogger("porkbun_ddns")
+
+DEFAULT_WEBHOOK_TEMPLATE: str = (
+    '{"text": "IP changed: {{ old_ips | join(\', \') }} -> '
+    '{{ new_ips | join(\', \') }} ({{ domain }})"}'
+)
+
+
+def _webhook_context(changes: Sequence[dict[str, Any]],
+                     domain: str) -> dict[str, Any]:
+    """Build the template context for the given changes.
+    """
+    old_ips = list(dict.fromkeys(
+        change["old_ip"] for change in changes if change["old_ip"] is not None))
+    new_ips = list(dict.fromkeys(
+        change["new_ip"] for change in changes if change["new_ip"] is not None))
+    return {
+        "changes": list(changes),
+        "old_ips": old_ips,
+        "new_ips": new_ips,
+        "domain": domain,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def render_webhook_payload(changes: Sequence[dict[str, Any]],
+                           domain: str,
+                           template: str | None = None,
+                           template_file: str | None = None) -> str:
+    """Render the webhook payload for the given changes.
+
+    Template precedence: file > inline > built-in default. A missing or
+    unreadable template file, or a template that fails to render, falls back to
+    the next precedence level instead of crashing.
+    """
+    template_source = DEFAULT_WEBHOOK_TEMPLATE
+    if template:
+        template_source = template
+    if template_file:
+        try:
+            template_source = Path(template_file).read_text()
+        except OSError as err:
+            fallback = "inline template" if template else "default template"
+            logger.warning(
+                "Failed to read webhook template file '%s': %s. "
+                "Falling back to the %s.", template_file, err, fallback)
+    context = _webhook_context(changes, domain)
+    try:
+        return jinja2.Environment().from_string(template_source).render(**context)
+    except jinja2.TemplateError as err:
+        logger.warning(
+            "Failed to render webhook template: %s. "
+            "Falling back to the default template.", err)
+        return jinja2.Environment().from_string(
+            DEFAULT_WEBHOOK_TEMPLATE).render(**context)
+
+
+def send_webhook(url: str, payload: str) -> None:
+    """POST the rendered payload to the webhook URL.
+
+    Fire-and-forget: non-2xx responses, timeouts and connection errors are
+    logged as warnings and never raise.
+    """
+    try:
+        request = urllib.request.Request(
+            url,
+            data=payload.encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=10) as response:
+            if not 200 <= response.getcode() < 300:
+                logger.warning(
+                    "Webhook returned non-2xx status code: %s",
+                    response.getcode())
+    except Exception as err:  # noqa: BLE001 - fire-and-forget, never crash the loop
+        logger.warning("Failed to send webhook to %s: %s", url, err)
+
+
+def fire_webhook(config: Config,
+                 changes: Sequence[dict[str, Any]],
+                 domain: str) -> bool:
+    """Render and send one aggregated webhook for the given changes.
+
+    Sends nothing when no webhook URL is configured or no changes were
+    recorded. Returns ``True`` when a webhook was sent.
+    """
+    if not config.webhook_url or not changes:
+        return False
+    payload = render_webhook_payload(
+        changes,
+        domain,
+        template=config.webhook_template,
+        template_file=config.webhook_template_file,
+    )
+    send_webhook(config.webhook_url, payload)
+    return True

--- a/porkbun_ddns/webhook.py
+++ b/porkbun_ddns/webhook.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import logging
 import urllib.request
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+try:  # datetime.UTC is Python 3.11+; keep 3.10 support
+    from datetime import UTC
+except ImportError:  # pragma: no cover - 3.10 fallback
+    from datetime import timezone as UTC
 
 import jinja2
 
@@ -34,7 +39,7 @@ def _webhook_context(changes: Sequence[dict[str, Any]],
         "old_ips": old_ips,
         "new_ips": new_ips,
         "domain": domain,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 keywords = ["porkbun", "ddns"]
-dependencies = ["xdg-base-dirs~=6.0.2"]
+dependencies = ["xdg-base-dirs~=6.0.2", "jinja2"]
 
 [project.urls]
 repository = "https://github.com/mietzen/porkbun-ddns"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 xdg-base-dirs~=6.0.2
+jinja2


### PR DESCRIPTION
Closes #116

## Summary
Adds a webhook notification fired when the DDNS records change. One aggregated POST per run, templated with Jinja2 so it works with Slack, MS Teams, Mattermost, Google Chat and friends.

## Changes
- `porkbun_ddns/config.py`: new `Config` fields `webhook_url`, `webhook_template`, `webhook_template_file`; `WEBHOOK_CONFIG_FIELDS` marks fields excluded from the Porkbun API request body
- `porkbun_ddns/webhook.py`: new module — renders the Jinja2 template (file > inline > built-in default) and fires the POST fire-and-forget (timeout, warn on failure, never crashes)
- `porkbun_ddns/porkbun_ddns.py`: `update_records()` records `changes` (record_type, fqdn, old_ip/new_ip) — core class stays pure; caller fires the webhook after a full pass
- `porkbun_ddns/cli.py`: `--webhook-url`, `--webhook-template`, `--webhook-template-file` flags; caller-fired after run loop
- `Docker/entrypoint.py`: `WEBHOOK_URL`, `WEBHOOK_TEMPLATE`, `WEBHOOK_TEMPLATE_FILE` env vars; fires once per loop pass when changes occurred
- `Docker/docker-compose.yml`: documents the new variables
- `pyproject.toml` + `requirements.txt`: `jinja2` dependency

## Template context
`changes` (list of `{record_type, fqdn, old_ip|None, new_ip}`), `old_ips`, `new_ips`, `domain`, `timestamp` (ISO-8601 UTC)

Default template: `{"text": "IP changed: {{ old_ips | join(', ') }} -> {{ new_ips | join(', ') }} ({{ domain }})"}`

## Verification
- 34 tests pass (17 new webhook tests)
- `ruff check --ignore=E501 --exclude=__init__.py ./porkbun_ddns` clean
- API request body unchanged (webhook fields excluded)

## Acceptance criteria
- [x] POST on IP change with templated payload
- [x] Slack/MS Teams-compatible default format
- [x] One aggregated notification per run
- [x] Fire-and-forget (never crashes DDNS updates)
- [x] Configurable via CLI, env, and config file