### PR TITLE
Update docs for retry, webhook and log-level features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ porkbun_ddns/            # Python package
 ├── cli.py               # CLI entry point (porkbun-ddns command)
 ├── config.py            # Configuration handling
 ├── helpers.py           # Utility functions
+├── webhook.py           # Jinja-templated webhook delivery
 ├── errors.py            # Custom exceptions
 └── test/                # pytest unit tests
 
@@ -102,11 +103,11 @@ Docker integration tests use cinc-auditor (inspec) and run automatically in CI. 
 ## Coding Conventions
 
 - **Version:** Dynamic via `VERSION` env var in `setup.py` — never hardcoded
-- **Dependencies:** `xdg-base-dirs~=6.0.2` (pinned minor)
+- **Dependencies:** `xdg-base-dirs~=6.0.2` (pinned minor), `jinja2` (webhook templating)
 - **CLI entry point:** `porkbun-ddns` → `porkbun_ddns.cli:main`
 - **Docker entry point:** `/entrypoint.py` — all config via environment variables:
   - Required: `DOMAIN`, `APIKEY`, `SECRETAPIKEY`
-  - Optional: `SUBDOMAINS`, `PUBLIC_IPS`, `FRITZBOX`, `IPV4`, `IPV6`, `SLEEP`, `DEBUG`
+  - Optional: `SUBDOMAINS`, `PUBLIC_IPS`, `FRITZBOX`, `IPV4`, `IPV6`, `SLEEP`, `DEBUG`, `LOG_LEVEL`, `RETRY_COUNT`, `RETRY_DELAY`, `WEBHOOK_URL`, `WEBHOOK_TEMPLATE`, `WEBHOOK_TEMPLATE_FILE`
 - **Multi-arch builds:** Platform list in `.github/platforms.json`, not hardcoded in workflows
 - **Secrets:** GitHub App token (APP_ID + APP_PRIVATE_KEY) for CI automation, Docker Hub credentials for image publishing, PyPI trusted publisher (no token needed)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install porkbun-ddns
 ## Usage
 
 ```Shell
-usage: porkbun-ddns [-h] [-c CONFIG] [-e ENDPOINT] [-pk APIKEY] [-sk SECRETAPIKEY] [-i [PUBLIC_IPS ...]] [-f FRITZBOX] [-4 | -6] [-v] [--env_only] domain [subdomains ...]
+usage: porkbun-ddns [-h] [-c CONFIG] [-e ENDPOINT] [-pk APIKEY] [-sk SECRETAPIKEY] [--retry-count RETRY_COUNT] [--retry-delay RETRY_DELAY] [--webhook-url WEBHOOK_URL] [--webhook-template WEBHOOK_TEMPLATE] [--webhook-template-file WEBHOOK_TEMPLATE_FILE] [--log-level LOG_LEVEL] [-i [PUBLIC_IPS ...]] [-f FRITZBOX] [-4 | -6] [-v] [--env_only] domain [subdomains ...]
 
 positional arguments:
   domain                Domain to be updated
@@ -52,6 +52,18 @@ options:
                         The Porkbun-API-key
   -sk SECRETAPIKEY, --secretapikey SECRETAPIKEY
                         The secret API-key
+  --retry-count RETRY_COUNT
+                        Number of attempts for transient API failures (default: 3)
+  --retry-delay RETRY_DELAY
+                        Seconds to wait between retry attempts (default: 5)
+  --webhook-url WEBHOOK_URL
+                        Webhook URL to notify when IPs change
+  --webhook-template WEBHOOK_TEMPLATE
+                        Jinja2 template for the webhook payload
+  --webhook-template-file WEBHOOK_TEMPLATE_FILE
+                        Path to a file containing the Jinja2 webhook template (takes precedence over --webhook-template)
+  --log-level LOG_LEVEL
+                        Set log verbosity (DEBUG, INFO, WARNING, ERROR, CRITICAL)
   -i [PUBLIC_IPS ...], --public-ips [PUBLIC_IPS ...]
                         Public IPs (v4 and or v6)
   -f FRITZBOX, --fritzbox FRITZBOX
@@ -71,6 +83,52 @@ These parameter are required for each run of the program. The program will take 
 3. The config-file (`apikey="pk_xxx"`)
 
 So if a value is set through the CLI and in the file, the CLI-value will be used. This allows for a default-configuration in the config-file, whose settings can be selectively overridden through enviromnment-variables or CLI-arguments.
+
+### The parameters *retry_count*, *retry_delay*
+
+Transient API failures (unreachable endpoint, timeouts, HTTP 5xx) are retried automatically. HTTP 4xx errors (e.g. invalid API keys) are not retried and fail immediately.
+
+- `retry_count`: number of attempts (default `3`)
+- `retry_delay`: seconds to wait between attempts (default `5`)
+
+These are optional and can be set via CLI (`--retry-count`, `--retry-delay`), environment variables (`PORKBUN_RETRY_COUNT`, `PORKBUN_RETRY_DELAY`) or the config-file (`retry_count`, `retry_delay`).
+
+### The parameters *webhook_url*, *webhook_template*, *webhook_template_file*
+
+When the IP(s) of your records change, an aggregated webhook notification can be POSTed to a URL of your choice. This works out of the box with Slack, MS Teams, Mattermost and Google Chat.
+
+- `webhook_url`: the URL to POST the notification to. Unset disables webhook notifications.
+- `webhook_template`: an inline [Jinja2](https://jinja.palletsprojects.com/) template for the payload.
+- `webhook_template_file`: path to a file containing a Jinja2 template. Takes precedence over `webhook_template`.
+
+These are optional and can be set via CLI (`--webhook-url`, `--webhook-template`, `--webhook-template-file`), environment variables (`PORKBUN_WEBHOOK_URL`, `PORKBUN_WEBHOOK_TEMPLATE`, `PORKBUN_WEBHOOK_TEMPLATE_FILE`) or the config-file (`webhook_url`, `webhook_template`, `webhook_template_file`). In Docker they are set via `WEBHOOK_URL`, `WEBHOOK_TEMPLATE` and `WEBHOOK_TEMPLATE_FILE`.
+
+Template precedence: **file > inline > built-in default**. The built-in default produces a Slack-compatible payload:
+
+```json
+{"text": "IP changed: {{ old_ips | join(', ') }} -> {{ new_ips | join(', ') }} ({{ domain }})"}
+```
+
+The following context variables are available in templates:
+
+| Variable    | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `changes`   | List of changes, each `{record_type, fqdn, old_ip\|None, new_ip}`            |
+| `old_ips`   | List of the previous IPs (only those that changed)                          |
+| `new_ips`   | List of the new IPs (only those that changed)                               |
+| `domain`    | The domain that was updated                                                 |
+| `timestamp` | ISO-8601 UTC timestamp of the notification                                  |
+
+One notification is sent per run, after all records have been updated. Notifications are fire-and-forget: a failure to deliver never crashes the update loop.
+
+### The parameter *log_level*
+
+Controls log verbosity. Accepts standard logging level names, case-insensitively: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (default `INFO`).
+
+- CLI: `--log-level WARNING`
+- Docker: `LOG_LEVEL=WARNING`
+
+When both the legacy `--verbose`/`DEBUG` and `LOG_LEVEL` are set, `LOG_LEVEL` wins. An invalid value logs a warning and falls back to `INFO` — it never crashes.
 
 ### Examples
 
@@ -115,7 +173,10 @@ You can set up a cron job get the full path to porkbun-ddns with `which porkbun-
 {
   "endpoint":"https://api.porkbun.com/api/json/v3",
   "apikey": "pk1_xxx",
-  "secretapikey": "sk1_xxx"
+  "secretapikey": "sk1_xxx",
+  "retry_count": "3",
+  "retry_delay": "5",
+  "webhook_url": "https://hooks.slack.com/services/..."
 }
 ```
 
@@ -137,6 +198,12 @@ services:
       # IPV4: "TRUE" # Set IPv4 address
       # IPV6: "TRUE" # Set IPv6 address
       # DEBUG: "FALSE" # DEBUG LOGGING
+      # LOG_LEVEL: "WARNING" # Set log verbosity (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+      # RETRY_COUNT: "3" # Number of attempts for transient API failures
+      # RETRY_DELAY: "5" # Seconds to wait between retry attempts
+      # WEBHOOK_URL: "https://hooks.slack.com/services/..." # POST an IP-change notification to this URL (Slack, MS Teams, Mattermost, Google Chat compatible by default)
+      # WEBHOOK_TEMPLATE: '{"text": "IP changed: {{ old_ips | join(", ") }} -> {{ new_ips | join(", ") }} ({{ domain }})"}' # Optional custom Jinja2 template
+      # WEBHOOK_TEMPLATE_FILE: "/path/to/template.j2" # Optional Jinja2 template file (takes precedence over WEBHOOK_TEMPLATE)
     restart: unless-stopped
 
 # # Uncomment below to let it detect ipv6 address:
@@ -157,6 +224,8 @@ docker run -d \
   -e SUBDOMAINS="my_subdomain,my_other_subdomain,my_subsubdomain.my_subdomain" \
   -e SECRETAPIKEY="<YOUR-SECRETAPIKEY>" \
   -e APIKEY="<YOUR-APIKEY>" \
+  -e LOG_LEVEL="WARNING" \
+  -e WEBHOOK_URL="https://hooks.slack.com/services/..." \
   --name porkbun-ddns \
   --restart unless-stopped \
   mietzen/porkbun-ddns:latest

--- a/README.md
+++ b/README.md
@@ -84,51 +84,43 @@ These parameter are required for each run of the program. The program will take 
 
 So if a value is set through the CLI and in the file, the CLI-value will be used. This allows for a default-configuration in the config-file, whose settings can be selectively overridden through enviromnment-variables or CLI-arguments.
 
-### The parameters *retry_count*, *retry_delay*
+### The parameter *retry_count*, *retry_delay*
 
-Transient API failures (unreachable endpoint, timeouts, HTTP 5xx) are retried automatically. HTTP 4xx errors (e.g. invalid API keys) are not retried and fail immediately.
+Transient API failures (unreachable endpoint, timeouts, HTTP 5xx) are retried automatically, HTTP 4xx errors (e.g. invalid API keys) fail immediately. Default is 3 attempts with a 5 seconds delay between them.
 
-- `retry_count`: number of attempts (default `3`)
-- `retry_delay`: seconds to wait between attempts (default `5`)
+The program will take the values for these (in this order) from:
 
-These are optional and can be set via CLI (`--retry-count`, `--retry-delay`), environment variables (`PORKBUN_RETRY_COUNT`, `PORKBUN_RETRY_DELAY`) or the config-file (`retry_count`, `retry_delay`).
+1. The command-line-arguments (`--retry-count 3`)
+2. The environment-variables (`export PORKBUN_RETRY_COUNT='3'`)
+3. The config-file (`retry_count="3"`)
 
-### The parameters *webhook_url*, *webhook_template*, *webhook_template_file*
+### The parameter *webhook_url*, *webhook_template*, *webhook_template_file*
 
-When the IP(s) of your records change, an aggregated webhook notification can be POSTed to a URL of your choice. This works out of the box with Slack, MS Teams, Mattermost and Google Chat.
+When the IP(s) of your records change, an aggregated webhook-notification can be POSTed to a URL of your choice. This works out of the box with Slack, MS Teams, Mattermost and Google Chat.
 
-- `webhook_url`: the URL to POST the notification to. Unset disables webhook notifications.
-- `webhook_template`: an inline [Jinja2](https://jinja.palletsprojects.com/) template for the payload.
-- `webhook_template_file`: path to a file containing a Jinja2 template. Takes precedence over `webhook_template`.
+The program will take the values for these (in this order) from:
 
-These are optional and can be set via CLI (`--webhook-url`, `--webhook-template`, `--webhook-template-file`), environment variables (`PORKBUN_WEBHOOK_URL`, `PORKBUN_WEBHOOK_TEMPLATE`, `PORKBUN_WEBHOOK_TEMPLATE_FILE`) or the config-file (`webhook_url`, `webhook_template`, `webhook_template_file`). In Docker they are set via `WEBHOOK_URL`, `WEBHOOK_TEMPLATE` and `WEBHOOK_TEMPLATE_FILE`.
+1. The command-line-arguments (`--webhook-url 'https://...'`)
+2. The environment-variables (`export PORKBUN_WEBHOOK_URL='https://...'`)
+3. The config-file (`webhook_url="https://..."`)
 
-Template precedence: **file > inline > built-in default**. The built-in default produces a Slack-compatible payload:
+In Docker use the `WEBHOOK_URL`, `WEBHOOK_TEMPLATE` and `WEBHOOK_TEMPLATE_FILE` environment-variables instead.
+
+The payload can be customized with an inline Jinja2-template (`--webhook-template`) or a template-file (`--webhook-template-file`), where the file takes precedence over the inline one. If neither is set, the following Slack-compatible default is used:
 
 ```json
 {"text": "IP changed: {{ old_ips | join(', ') }} -> {{ new_ips | join(', ') }} ({{ domain }})"}
 ```
 
-The following context variables are available in templates:
+The following context-variables are available in templates: `changes` (list of changes, each `{record_type, fqdn, old_ip|None, new_ip}`), `old_ips` (previous IPs), `new_ips` (new IPs), `domain` (the updated domain) and `timestamp` (ISO-8601 UTC timestamp of the notification).
 
-| Variable    | Description                                                                 |
-| ----------- | --------------------------------------------------------------------------- |
-| `changes`   | List of changes, each `{record_type, fqdn, old_ip\|None, new_ip}`            |
-| `old_ips`   | List of the previous IPs (only those that changed)                          |
-| `new_ips`   | List of the new IPs (only those that changed)                               |
-| `domain`    | The domain that was updated                                                 |
-| `timestamp` | ISO-8601 UTC timestamp of the notification                                  |
-
-One notification is sent per run, after all records have been updated. Notifications are fire-and-forget: a failure to deliver never crashes the update loop.
+One notification is sent per run, after all records have been updated. Notifications are fire-and-forget: a failure to deliver never crashes the update-loop.
 
 ### The parameter *log_level*
 
-Controls log verbosity. Accepts standard logging level names, case-insensitively: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (default `INFO`).
+Controls the verbosity of the logs. Accepts standard logging level names, case-insensitively: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (default `INFO`). Set it via `--log-level WARNING` on the CLI or `LOG_LEVEL=WARNING` in Docker.
 
-- CLI: `--log-level WARNING`
-- Docker: `LOG_LEVEL=WARNING`
-
-When both the legacy `--verbose`/`DEBUG` and `LOG_LEVEL` are set, `LOG_LEVEL` wins. An invalid value logs a warning and falls back to `INFO` — it never crashes.
+When both the legacy `--verbose`/`DEBUG` and `LOG_LEVEL` are set, `LOG_LEVEL` wins. An invalid value logs a warning and falls back to `INFO`, it never crashes.
 
 ### Examples
 


### PR DESCRIPTION
## Summary
Updates the documentation to cover the three recently merged features: retry on transient API failures (#113), webhook notifications (#116) and configurable log verbosity (#136).

## Changes

### README.md
- Updated the CLI usage block with the new flags: `--retry-count`, `--retry-delay`, `--webhook-url`, `--webhook-template`, `--webhook-template-file`, `--log-level`
- New section **retry_count / retry_delay** — defaults, configurable via CLI/env/config-file
- New section **webhook_url / webhook_template / webhook_template_file** — template precedence, context variables table, fire-and-forget semantics
- New section **log_level** — accepted values, CLI + Docker usage, precedence over legacy `--verbose`/`DEBUG`
- Updated `config.json` example with the new optional keys
- Updated `docker-compose.yml` example with `LOG_LEVEL`, `RETRY_COUNT`, `RETRY_DELAY`, `WEBHOOK_URL`, `WEBHOOK_TEMPLATE`, `WEBHOOK_TEMPLATE_FILE`
- Updated `docker run` example with `LOG_LEVEL` and `WEBHOOK_URL`

### AGENTS.md
- Added `webhook.py` to the repository structure
- Added `jinja2` to dependencies
- Added the six new Docker env vars to the optional env-var list

## Not changed
- `docs/agents/*.md` (issue-tracker, triage-labels, domain) — agent-process docs, not affected by the feature merges (verified accurate)