### PR TITLE
Allow overriding the Porkbun API endpoint via API_ENDPOINT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Docker integration tests use cinc-auditor (inspec) and run automatically in CI. 
 - **CLI entry point:** `porkbun-ddns` → `porkbun_ddns.cli:main`
 - **Docker entry point:** `/entrypoint.py` — all config via environment variables:
   - Required: `DOMAIN`, `APIKEY`, `SECRETAPIKEY`
-  - Optional: `SUBDOMAINS`, `PUBLIC_IPS`, `FRITZBOX`, `IPV4`, `IPV6`, `SLEEP`, `DEBUG`, `LOG_LEVEL`, `RETRY_COUNT`, `RETRY_DELAY`, `WEBHOOK_URL`, `WEBHOOK_TEMPLATE`, `WEBHOOK_TEMPLATE_FILE`
+  - Optional: `SUBDOMAINS`, `PUBLIC_IPS`, `FRITZBOX`, `IPV4`, `IPV6`, `SLEEP`, `DEBUG`, `LOG_LEVEL`, `RETRY_COUNT`, `RETRY_DELAY`, `WEBHOOK_URL`, `WEBHOOK_TEMPLATE`, `WEBHOOK_TEMPLATE_FILE`, `API_ENDPOINT`
 - **Multi-arch builds:** Platform list in `.github/platforms.json`, not hardcoded in workflows
 - **Secrets:** GitHub App token (APP_ID + APP_PRIVATE_KEY) for CI automation, Docker Hub credentials for image publishing, PyPI trusted publisher (no token needed)
 

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       SUBDOMAINS: "my_subdomain,my_other_subdomain,my_subsubdomain.my_subdomain" # Subdomains comma spreaded
       SECRETAPIKEY: "<YOUR-SECRETAPIKEY>" # Your Porkbun Secret-API-Key
       APIKEY: "<YOUR-APIKEY>" # Your Porkbun API-Key
+      # API_ENDPOINT: "https://api.porkbun.com/api/json/v3" # Override the Porkbun API endpoint (e.g. a mirror/proxy)
       # PUBLIC_IPS: "1.2.3.4,2001:043e::1" # Set if you got static IP's
       # FRITZBOX: "192.168.178.1" # Use Fritz!BOX to obtain Public IP's
       # SLEEP: "300" # Seconds to sleep between DynDNS runs

--- a/Docker/entrypoint.py
+++ b/Docker/entrypoint.py
@@ -33,7 +33,7 @@ if os.getenv('PUBLIC_IPS', None):
 fritzbox = os.getenv('FRITZBOX', None)
 
 config = Config(
-    DEFAULT_ENDPOINT,
+    os.getenv('API_ENDPOINT', DEFAULT_ENDPOINT),
     os.getenv('APIKEY'),
     os.getenv('SECRETAPIKEY'),
     retry_count=os.getenv('RETRY_COUNT', '3'),

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ These parameter are required for each run of the program. The program will take 
 2. The environment-variables (`export PORKBUN_APIKEY='pk1_xxx'`)
 3. The config-file (`apikey="pk_xxx"`)
 
+In Docker use the `API_ENDPOINT` environment-variable instead.
+
 So if a value is set through the CLI and in the file, the CLI-value will be used. This allows for a default-configuration in the config-file, whose settings can be selectively overridden through enviromnment-variables or CLI-arguments.
 
 ### The parameter *retry_count*, *retry_delay*
@@ -184,6 +186,7 @@ services:
       SUBDOMAINS: "my_subdomain,my_other_subdomain,my_subsubdomain.my_subdomain" # Subdomains comma spreaded
       SECRETAPIKEY: "<YOUR-SECRETAPIKEY>" # Your Porkbun Secret-API-Key
       APIKEY: "<YOUR-APIKEY>" # Your Porkbun API-Key
+      # API_ENDPOINT: "https://api.porkbun.com/api/json/v3" # Override the Porkbun API endpoint (e.g. a mirror/proxy)
       # PUBLIC_IPS: "1.2.3.4,2001:043e::1" # Set if you got static IP's
       # FRITZBOX: "192.168.178.1" # Use Fritz!BOX to obtain Public IP's
       # SLEEP: "300" # Seconds to sleep between DynDNS runs


### PR DESCRIPTION
## What
Adds an `API_ENDPOINT` environment variable to the Docker entrypoint, defaulting to `DEFAULT_ENDPOINT` (`https://api.porkbun.com/api/json/v3`).

## Why
The Python package already supports endpoint override (CLI `--endpoint`, `PORKBUN_ENDPOINT` env, config-file `endpoint`). The Docker entrypoint hardcoded `DEFAULT_ENDPOINT`, so the container could not be pointed at a mirror/proxy or a local mock. This makes the Docker surface consistent with the package.

## Changes
- `Docker/entrypoint.py`: `os.getenv('API_ENDPOINT', DEFAULT_ENDPOINT)`
- `Docker/docker-compose.yml`: documented commented example
- `README.md` + `AGENTS.md`: document the env var

## Testing
- pytest: 49 passed
- ruff: clean
- No package code changed.