### PR TITLE
Add mock-based e2e tests and live API canary

### DIFF
--- a/.github/platforms.json
+++ b/.github/platforms.json
@@ -1,1 +1,6 @@
-{"platforms":["linux/amd64","linux/arm64","linux/arm/v7","linux/arm/v6"]}
+{"platforms":[
+  {"platform": "linux/amd64", "runner": "ubuntu-latest"},
+  {"platform": "linux/arm64", "runner": "ubuntu-24.04-arm"},
+  {"platform": "linux/arm/v7", "runner": "ubuntu-latest"},
+  {"platform": "linux/arm/v6", "runner": "ubuntu-latest"}
+]}

--- a/.github/workflows/api-canary.yml
+++ b/.github/workflows/api-canary.yml
@@ -1,0 +1,25 @@
+name: API Canary
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff pytest jsonschema
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run live API + spec conformance tests
+        run: pytest ./porkbun_ddns/test/test_live_api.py -v

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -44,7 +44,7 @@ jobs:
         echo "build_matrix=$(cat .github/platforms.json)" >> $GITHUB_OUTPUT
 
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platforms.runner }}
     needs: Setup
     strategy:
       fail-fast: false
@@ -68,7 +68,7 @@ jobs:
       env:
         DOCKER_USER: ${{ vars.DOCKER_HUB_USERNAME || 'user' }}
         BUILD_NR: ${{ github.run_number }}
-        PLATFORM: ${{ matrix.platforms }}
+        PLATFORM: ${{ matrix.platforms.platform }}
         VERSION: ${{ needs.Setup.outputs.version }}
       run: |
         ARCH=$(echo "${PLATFORM}" | awk -F  "/" '{print $2$3}')
@@ -88,7 +88,7 @@ jobs:
       env:
         DOCKER_USER: ${{ vars.DOCKER_HUB_USERNAME || 'user' }}
         BUILD_NR: ${{ github.run_number }}
-        PLATFORM: ${{ matrix.platforms }}
+        PLATFORM: ${{ matrix.platforms.platform }}
         VERSION: ${{ needs.Setup.outputs.version }}
       working-directory: './Docker'
       run: |
@@ -112,7 +112,7 @@ jobs:
       env:
         DOCKER_USER: ${{ vars.DOCKER_HUB_USERNAME || 'user' }}
         BUILD_NR: ${{ github.run_number }}
-        PLATFORM: ${{ matrix.platforms }}
+        PLATFORM: ${{ matrix.platforms.platform }}
         VERSION: ${{ needs.Setup.outputs.version }}
       run: |
         ARCH=$(echo "${PLATFORM}" | awk -F  "/" '{print $2$3}')
@@ -158,13 +158,13 @@ jobs:
         while read -r PLATFORM; do
           ARCH=$(echo "${PLATFORM}" | awk -F  "/" '{print $2$3}')
           echo -n " ${DOCKER_USER}/porkbun-ddns:${VERSION}-${ARCH}-${BUILD_NR}" >> push-shared-tags.sh
-        done <<< "$(cat .github/platforms.json | jq -r '.platforms | join("\n")')"
+        done <<< "$(cat .github/platforms.json | jq -r '.platforms[] | .platform')"
         echo "" >> push-shared-tags.sh
         echo -n "docker manifest create ${DOCKER_USER}/porkbun-ddns:latest" >> push-shared-tags.sh
         while read -r PLATFORM; do
           ARCH=$(echo "${PLATFORM}" | awk -F  "/" '{print $2$3}')
           echo -n " ${DOCKER_USER}/porkbun-ddns:${VERSION}-${ARCH}-${BUILD_NR}" >> push-shared-tags.sh
-        done <<< "$(cat .github/platforms.json | jq -r '.platforms | join("\n")')"
+        done <<< "$(cat .github/platforms.json | jq -r '.platforms[] | .platform')"
         echo "" >> push-shared-tags.sh
         echo "docker manifest push ${DOCKER_USER}/porkbun-ddns:${VERSION}" >> push-shared-tags.sh
         echo "docker manifest push ${DOCKER_USER}/porkbun-ddns:latest" >> push-shared-tags.sh

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -41,7 +41,11 @@ jobs:
           exit 1
         fi
         echo "version=$(echo ${VERSION})" >> $GITHUB_OUTPUT
-        echo "build_matrix=$(cat .github/platforms.json)" >> $GITHUB_OUTPUT
+        {
+          echo "build_matrix<<EOF"
+          cat .github/platforms.json
+          echo "EOF"
+        } >> $GITHUB_OUTPUT
 
   Build:
     runs-on: ${{ matrix.platforms.runner }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
         echo "build_matrix=$(cat .github/platforms.json)" >> $GITHUB_OUTPUT
 
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platforms.runner }}
     needs: Setup
     strategy:
       fail-fast: false
@@ -64,7 +64,7 @@ jobs:
       env:
         DOCKER_USER: ${{ vars.DOCKER_HUB_USERNAME || 'user' }}
         BUILD_NR: ${{ github.run_number }}
-        PLATFORM: ${{ matrix.platforms }}
+        PLATFORM: ${{ matrix.platforms.platform }}
         VERSION: ${{ needs.Setup.outputs.version }}
       run: |
         ARCH=$(echo "${PLATFORM}" | awk -F  "/" '{print $2$3}')
@@ -84,7 +84,7 @@ jobs:
       env:
         DOCKER_USER: ${{ vars.DOCKER_HUB_USERNAME || 'user' }}
         BUILD_NR: ${{ github.run_number }}
-        PLATFORM: ${{ matrix.platforms }}
+        PLATFORM: ${{ matrix.platforms.platform }}
         VERSION: ${{ needs.Setup.outputs.version }}
       working-directory: './Docker'
       run: |
@@ -110,7 +110,7 @@ jobs:
       env:
         DOCKER_USER: ${{ vars.DOCKER_HUB_USERNAME || 'user' }}
         BUILD_NR: ${{ github.run_number }}
-        PLATFORM: ${{ matrix.platforms }}
+        PLATFORM: ${{ matrix.platforms.platform }}
         VERSION: ${{ needs.Setup.outputs.version }}
       run: |
         ARCH=$(echo "${PLATFORM}" | awk -F  "/" '{print $2$3}')
@@ -157,13 +157,13 @@ jobs:
         while read -r PLATFORM; do
           ARCH=$(echo "${PLATFORM}" | awk -F  "/" '{print $2$3}')
           echo -n " ${DOCKER_USER}/porkbun-ddns:${VERSION}-${ARCH}-${BUILD_NR}" >> push-shared-tags.sh
-        done <<< "$(cat .github/platforms.json | jq -r '.platforms | join("\n")')"
+        done <<< "$(cat .github/platforms.json | jq -r '.platforms[] | .platform')"
         echo "" >> push-shared-tags.sh
         echo -n "docker manifest create ${DOCKER_USER}/porkbun-ddns:latest" >> push-shared-tags.sh
         while read -r PLATFORM; do
           ARCH=$(echo "${PLATFORM}" | awk -F  "/" '{print $2$3}')
           echo -n " ${DOCKER_USER}/porkbun-ddns:${VERSION}-${ARCH}-${BUILD_NR}" >> push-shared-tags.sh
-        done <<< "$(cat .github/platforms.json | jq -r '.platforms | join("\n")')"
+        done <<< "$(cat .github/platforms.json | jq -r '.platforms[] | .platform')"
         echo "" >> push-shared-tags.sh
         echo "docker manifest push ${DOCKER_USER}/porkbun-ddns:${VERSION}" >> push-shared-tags.sh
         echo "docker manifest push ${DOCKER_USER}/porkbun-ddns:latest" >> push-shared-tags.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,11 @@ jobs:
           fi
         fi
         echo "version=$(echo ${VERSION})" >> $GITHUB_OUTPUT
-        echo "build_matrix=$(cat .github/platforms.json)" >> $GITHUB_OUTPUT
+        {
+          echo "build_matrix<<EOF"
+          cat .github/platforms.json
+          echo "EOF"
+        } >> $GITHUB_OUTPUT
 
   Build:
     runs-on: ${{ matrix.platforms.runner }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,6 +90,7 @@ jobs:
         BUILD_NR: ${{ github.run_number }}
         PLATFORM: ${{ matrix.platforms.platform }}
         VERSION: ${{ needs.Setup.outputs.version }}
+        CI_DEBUG_MODE: ${{ runner.debug }}
       working-directory: './Docker'
       run: |
         set -a

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pytest
+          pip install ruff pytest jsonschema
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Test with pytest
         run: |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,12 +11,16 @@ DNS records, only updating when IPs change.
   API or real DNS records.
   _Avoid_: integration test, smoke test
 
+- **container e2e test**: A test that runs the real Docker image (with its real entrypoint) against the mock running as a sidecar container, verifying env-var wiring (e.g. `API_ENDPOINT`) end-to-end. Runs in docker.yml via `Docker/test/e2e.sh` on the native-runner platforms.
+
 - **smoke test**: A manual live-API harness (`local_test.py`, gitignored)
   that exercises real DNS records on a real domain with real API keys.
   _Avoid_: e2e test
 
 - **mock**: The hand-written fake of the Porkbun JSON API v3 used by e2e
-  tests, covering only the DNS endpoints the client calls.
+  tests, covering only the DNS endpoints the client calls. It also runs
+  standalone as a docker sidecar (via a `__main__` block) for the container
+  e2e test.
 
 - **fault injection**: The mock's `fail_next` counter, which makes the next N
   requests return HTTP 500 so the client's retry logic can be tested

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,31 @@
+# Context: porkbun-ddns
+
+porkbun-ddns is an unofficial DDNS client for Porkbun. It runs as a pip
+package or a Docker container, and sets/updates A (IPv4) and AAAA (IPv6)
+DNS records, only updating when IPs change.
+
+## Glossary
+
+- **e2e test**: A hermetic test that runs the client's full request path
+  (Config → PorkbunDDNS → HTTP → mock API) without touching the real Porkbun
+  API or real DNS records.
+  _Avoid_: integration test, smoke test
+
+- **smoke test**: A manual live-API harness (`local_test.py`, gitignored)
+  that exercises real DNS records on a real domain with real API keys.
+  _Avoid_: e2e test
+
+- **mock**: The hand-written fake of the Porkbun JSON API v3 used by e2e
+  tests, covering only the DNS endpoints the client calls.
+
+- **fault injection**: The mock's `fail_next` counter, which makes the next N
+  requests return HTTP 500 so the client's retry logic can be tested
+  end-to-end.
+
+- **endpoint override**: Pointing the client at a non-default API base URL
+  (CLI `--endpoint`, `PORKBUN_ENDPOINT`/`API_ENDPOINT` env vars, config-file
+  `endpoint`) — used to run against a mirror, proxy, or the mock.
+
+- **canary**: A scheduled check (GitHub Actions `api-canary.yml`) that
+  verifies the default API endpoint is reachable and the mock still conforms
+  to the live API spec.

--- a/Docker/test/e2e.sh
+++ b/Docker/test/e2e.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -x
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( cd "${SCRIPT_DIR}/../.." &> /dev/null && pwd )
+
+# The e2e runs on the two native-runner platforms; arm/v6+v7 skip it.
+if [[ "${PLATFORM}" != "linux/amd64" && "${PLATFORM}" != "linux/arm64" ]]; then
+    echo "Skipping Docker e2e on ${PLATFORM} (native-runner platforms only)"
+    exit 0
+fi
+
+NETWORK=porkbun-ddns-e2e
+MOCK_CONTAINER=porkbun-ddns-mock
+APP_CONTAINER=porkbun-ddns-e2e
+MOCK_PORT=18080
+IMAGE="${DOCKER_USER}/porkbun-ddns:${VERSION}-${ARCH}-${BUILD_NR}"
+APIKEY=test-apikey
+SECRETAPIKEY=test-secret
+PINNED_IP=203.0.113.5
+
+cleanup() {
+    docker container stop ${APP_CONTAINER} >/dev/null 2>&1 || true
+    docker container stop ${MOCK_CONTAINER} >/dev/null 2>&1 || true
+    docker network rm ${NETWORK} >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+docker network create ${NETWORK}
+
+# Sidecar mock: native-arch python, runs the repo's mock standalone.
+docker run -d --rm --name ${MOCK_CONTAINER} \
+    --network ${NETWORK} \
+    -p 127.0.0.1:${MOCK_PORT}:8000 \
+    -e APIKEY=${APIKEY} \
+    -e SECRETAPIKEY=${SECRETAPIKEY} \
+    -e HOST=0.0.0.0 \
+    -e PORT=8000 \
+    -v "${REPO_ROOT}/porkbun_ddns/test/mock_porkbun_api.py":/mock.py \
+    python:3.13-slim \
+    python /mock.py
+
+# Wait until the mock answers (any HTTP response proves the server is up).
+for _ in $(seq 1 15); do
+    if curl -s -o /dev/null "http://127.0.0.1:${MOCK_PORT}/api/json/v3/dns/retrieve/example.com"; then
+        break
+    fi
+    sleep 2
+done
+
+# The real image, real entrypoint, API_ENDPOINT -> mock, IPs pinned.
+docker run -d --rm --name ${APP_CONTAINER} \
+    --platform ${PLATFORM} \
+    --network ${NETWORK} \
+    -e DOMAIN=example.com \
+    -e APIKEY=${APIKEY} \
+    -e SECRETAPIKEY=${SECRETAPIKEY} \
+    -e API_ENDPOINT="http://${MOCK_CONTAINER}:8000/api/json/v3" \
+    -e PUBLIC_IPS=${PINNED_IP} \
+    -e IPV6=FALSE \
+    -e SLEEP=301 \
+    "${IMAGE}"
+
+# Poll the mock until the container's update pass created the record.
+RETRIEVE_URL="http://127.0.0.1:${MOCK_PORT}/api/json/v3/dns/retrieve/example.com"
+RECORDS="0"
+for _ in $(seq 1 60); do
+    RECORDS=$(curl -s -X POST "${RETRIEVE_URL}" \
+        -H "Content-Type: application/json" \
+        -d "{\"apikey\":\"${APIKEY}\",\"secretapikey\":\"${SECRETAPIKEY}\"}" \
+        | jq -r '.records | length' 2>/dev/null || echo "0")
+    if [[ "${RECORDS}" != "0" && -n "${RECORDS}" ]]; then
+        break
+    fi
+    sleep 2
+done
+[[ "${RECORDS}" != "0" && -n "${RECORDS}" ]] || fail "container never created the A record (records=${RECORDS})"
+
+CONTENT=$(curl -s -X POST "${RETRIEVE_URL}" \
+    -H "Content-Type: application/json" \
+    -d "{\"apikey\":\"${APIKEY}\",\"secretapikey\":\"${SECRETAPIKEY}\"}" \
+    | jq -r '.records[0].content' 2>/dev/null)
+[[ "${CONTENT}" == "${PINNED_IP}" ]] || fail "expected content ${PINNED_IP}, got ${CONTENT}"
+
+docker logs ${APP_CONTAINER} 2>&1 | grep -q "Creating A-Record for example.com" \
+    || fail "container log missing 'Creating A-Record for example.com'"
+
+echo "Docker e2e PASSED: ${IMAGE} updated the mock via API_ENDPOINT (content=${CONTENT})"

--- a/Docker/test/e2e.sh
+++ b/Docker/test/e2e.sh
@@ -88,9 +88,8 @@ CONTENT=$(curl -s -X POST "${RETRIEVE_URL}" \
     | jq -r '.records[0].content' 2>/dev/null)
 [[ "${CONTENT}" == "${PINNED_IP}" ]] || fail "expected content ${PINNED_IP}, got ${CONTENT}"
 
-docker_logs = "$(docker logs ${APP_CONTAINER})"
-echo $docker_logs
-echo $docker_logs | grep -q "Creating A-Record for example.com" \
+docker logs ${APP_CONTAINER}
+docker logs ${APP_CONTAINER} | grep -q "Creating A-Record for example.com" \
     || fail "container log missing 'Creating A-Record for example.com'"
 
 echo "Docker e2e PASSED: ${IMAGE} updated the mock via API_ENDPOINT (content=${CONTENT})"

--- a/Docker/test/e2e.sh
+++ b/Docker/test/e2e.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ ${{ runner.debug }} == 1 ]]; then
+if [[ $CI_DEBUG_MODE == 1 ]]; then
     set -x
 fi
 

--- a/Docker/test/e2e.sh
+++ b/Docker/test/e2e.sh
@@ -88,7 +88,9 @@ CONTENT=$(curl -s -X POST "${RETRIEVE_URL}" \
     | jq -r '.records[0].content' 2>/dev/null)
 [[ "${CONTENT}" == "${PINNED_IP}" ]] || fail "expected content ${PINNED_IP}, got ${CONTENT}"
 
-docker logs ${APP_CONTAINER} 2>&1 | grep -q "Creating A-Record for example.com" \
+docker_logs = "$(docker logs ${APP_CONTAINER})"
+echo $docker_logs
+echo $docker_logs | grep -q "Creating A-Record for example.com" \
     || fail "container log missing 'Creating A-Record for example.com'"
 
 echo "Docker e2e PASSED: ${IMAGE} updated the mock via API_ENDPOINT (content=${CONTENT})"

--- a/Docker/test/e2e.sh
+++ b/Docker/test/e2e.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-set -x
+if [[ ${{ runner.debug }} == 1 ]]; then
+    set -x
+fi
+
+set -eo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( cd "${SCRIPT_DIR}/../.." &> /dev/null && pwd )

--- a/Docker/test/test.sh
+++ b/Docker/test/test.sh
@@ -4,6 +4,12 @@ set -xe
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+echo ""
+echo "--------------------------------------"
+echo "Docker inspec"
+echo "--------------------------------------"
+echo ""
+
 echo "Setup"
 docker run -d --rm \
     --name porkbun-ddns \
@@ -20,5 +26,11 @@ echo "Test"
 inspec exec ./test/integration -t docker://porkbun-ddns
 echo "Teardown"
 docker container stop porkbun-ddns
+
+echo ""
+echo "--------------------------------------"
 echo "Docker e2e"
+echo "--------------------------------------"
+echo ""
+
 bash "${SCRIPT_DIR}/e2e.sh"

--- a/Docker/test/test.sh
+++ b/Docker/test/test.sh
@@ -20,3 +20,5 @@ echo "Test"
 inspec exec ./test/integration -t docker://porkbun-ddns
 echo "Teardown"
 docker container stop porkbun-ddns
+echo "Docker e2e"
+bash "${SCRIPT_DIR}/e2e.sh"

--- a/Docker/test/test.sh
+++ b/Docker/test/test.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-if [[ ${{ runner.debug }} == 1 ]]; then
+APT_SILENT='-qq -o=Dpkg::Use-Pty=0'
+
+if [[ $CI_DEBUG_MODE == 1 ]]; then
     set -x
+    APT_SILENT=''
 fi
 
 set -eo pipefail
@@ -23,8 +26,8 @@ docker run -d --rm \
     "${DOCKER_USER}/porkbun-ddns:${VERSION}-${ARCH}-${BUILD_NR}"
 
 # Install tools needed for inspect
-docker exec -u 0 porkbun-ddns apt-get update
-docker exec -u 0 porkbun-ddns apt-get install procps -y
+docker exec -u 0 porkbun-ddns apt-get update 
+docker exec -u 0 porkbun-ddns apt-get install procps -y $APT_SILENT
 
 echo "Test"
 inspec exec ./test/integration -t docker://porkbun-ddns

--- a/Docker/test/test.sh
+++ b/Docker/test/test.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-set -xe
+if [[ ${{ runner.debug }} == 1 ]]; then
+    set -x
+fi
+
+set -eo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/docs/adr/0001-focused-porkbun-api-mock-for-e2e-tests.md
+++ b/docs/adr/0001-focused-porkbun-api-mock-for-e2e-tests.md
@@ -1,0 +1,33 @@
+# 0001 — Focused Porkbun API Mock for E2E Tests
+
+- **Status:** accepted
+- **Date:** 2026-08-02
+
+## Context
+
+The client talks to the live Porkbun JSON API v3. We wanted hermetic
+end-to-end coverage of all features (retry, webhooks, IPv4/IPv6) without
+touching the real API or real DNS records.
+
+## Decision
+
+A focused hand-written stdlib mock covering only the 3 DNS endpoints the
+client calls (retrieve, create, delete). Response shapes are sourced from the
+official OpenAPI spec at https://porkbun.com/api/json/v3/spec, which is used
+as a reference — not a code generator. Plain `jsonschema` validates mock
+responses against the live spec in a network test that skips offline.
+
+## Considered Options
+
+- **Spec-driven full mock generated from the 167KB OpenAPI doc** — rejected:
+  heavy new CI dependencies for ~57 endpoints the client never touches.
+- **Live-API-only tests** — rejected: non-hermetic, requires real API keys.
+
+## Consequences
+
+- CI gains permanent regression coverage of retry, webhook, IPv4 and IPv6
+  behavior.
+- Spec drift or a default-endpoint outage surfaces as a CI or canary failure,
+  prompting a mock or config update.
+- The `nullable` keyword is ignored by jsonschema — the mock never returns
+  nulls, so validation passes.

--- a/docs/adr/0002-container-e2e-docker-sidecar-mock.md
+++ b/docs/adr/0002-container-e2e-docker-sidecar-mock.md
@@ -1,0 +1,39 @@
+# 0002 — Container-Level E2E via Sidecar Mock
+
+- **Status:** accepted
+- **Date:** 2026-08-02
+
+## Context
+
+The pytest e2e (ADR-0001) covers client logic against the in-process mock,
+but the real Docker image, its entrypoint, and the `API_ENDPOINT` env-var
+wiring (PR #146) were never exercised in CI — the existing inspec test mounts
+a replacement entrypoint over `/entrypoint.py`.
+
+## Decision
+
+docker.yml runs a container-level e2e after inspec: the mock runs as a
+sidecar `python:3.13-slim` container (native arch, no `--platform`) on a
+shared docker network; the real image runs with `API_ENDPOINT` pointing at
+the mock and `PUBLIC_IPS` pinned; `Docker/test/e2e.sh` asserts through the
+mock's real `/dns/retrieve` endpoint and greps the container logs. Runs on
+`linux/amd64` (ubuntu-latest) and `linux/arm64` (ubuntu-24.04-arm) only;
+arm/v7 + v6 keep QEMU builds and inspec but skip the e2e. `platforms.json`
+now carries a runner per platform.
+
+## Considered Options
+
+- **Host-side mock process** — rejected: relies on runner python setup + host
+  networking.
+- **e2e on all four arches** — rejected: QEMU arm/v6+v7 startup cost buys no
+  extra signal — the wiring under test is arch-independent Python.
+- **Mock control endpoint for assertions** — rejected: diverges from the real
+  API surface.
+
+## Consequences
+
+- Real image + entrypoint + `API_ENDPOINT` wiring verified in CI on both
+  native arch families.
+- The e2e is network-isolated (docker-internal), distinct from the pytest
+  e2e.
+- arm/v6+v7 image correctness still covered by build + inspec.

--- a/porkbun_ddns/test/mock_porkbun_api.py
+++ b/porkbun_ddns/test/mock_porkbun_api.py
@@ -52,13 +52,21 @@ class PorkbunAPIMock:
         host, port = self._server.server_address[:2]
         return f"http://{host}:{port}"
 
-    def start(self) -> PorkbunAPIMock:
-        """Bind an ephemeral port and serve requests on a daemon thread."""
-        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(self))
+    def start(self, host: str = "127.0.0.1", port: int = 0) -> PorkbunAPIMock:
+        """Bind a host/port (ephemeral by default) and serve on a daemon thread."""
+        self._server = ThreadingHTTPServer((host, port), _make_handler(self))
         self._thread = threading.Thread(
             target=self._server.serve_forever, daemon=True)
         self._thread.start()
         return self
+
+    def serve_forever(self) -> None:
+        """Serve requests on the current thread until ``stop`` is called.
+
+        Blocking; used by the standalone ``__main__`` runner (docker sidecar).
+        """
+        if self._server:
+            self._server.serve_forever()
 
     def stop(self) -> None:
         """Shut the server down and free the port."""
@@ -164,3 +172,21 @@ class PorkbunAPIMock:
         handler.send_header("Content-Length", str(len(body_bytes)))
         handler.end_headers()
         handler.wfile.write(body_bytes)
+
+
+if __name__ == "__main__":
+    import os
+
+    mock = PorkbunAPIMock(
+        apikey=os.getenv("APIKEY", "test-apikey"),
+        secretapikey=os.getenv("SECRETAPIKEY", "test-secret"),
+    )
+    mock.start(
+        host=os.getenv("HOST", "0.0.0.0"),
+        port=int(os.getenv("PORT", "8000")),
+    )
+    print(f"Mock Porkbun API listening on {mock.url}", flush=True)
+    try:
+        mock.serve_forever()
+    except KeyboardInterrupt:
+        mock.stop()

--- a/porkbun_ddns/test/mock_porkbun_api.py
+++ b/porkbun_ddns/test/mock_porkbun_api.py
@@ -1,0 +1,166 @@
+"""A hermetic, stdlib-only fake of the Porkbun JSON API v3.
+
+Covers exactly the three DNS endpoints the client calls (retrieve, create,
+delete) plus the authentication and fault-injection behaviour needed to
+exercise the client's retry and error handling end-to-end. Response shapes
+follow the official OpenAPI spec at https://porkbun.com/api/json/v3/spec.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import unquote
+
+
+def _make_handler(mock: PorkbunAPIMock) -> type[BaseHTTPRequestHandler]:
+    """Build a request handler bound to a specific mock instance."""
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            mock._handle(self)
+
+        def log_message(self, *args) -> None:  # silence default request logging
+            pass
+
+    return Handler
+
+
+class PorkbunAPIMock:
+    """In-process fake of the Porkbun JSON API v3.
+
+    Records are stored per domain in ``records`` (domain -> list of record
+    dicts). ``fail_next`` makes the next request fail with HTTP 500, and
+    ``request_count`` counts every request received. Every response sent is
+    recorded as ``(path, status, body)`` in ``responses``.
+    """
+
+    def __init__(self, apikey: str, secretapikey: str) -> None:
+        self.apikey = apikey
+        self.secretapikey = secretapikey
+        self.records: dict[str, list[dict]] = {}
+        self.fail_next = 0
+        self.request_count = 0
+        self.responses: list[tuple[str, int, dict | None]] = []
+        self._next_id = 1
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def url(self) -> str:
+        """Base URL of the mock, e.g. ``http://127.0.0.1:53421``."""
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def start(self) -> PorkbunAPIMock:
+        """Bind an ephemeral port and serve requests on a daemon thread."""
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(self))
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        """Shut the server down and free the port."""
+        if self._server:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+            self._thread = None
+
+    def _handle(self, handler: BaseHTTPRequestHandler) -> None:
+        self.request_count += 1
+        # Fault injection applies to any request, including auth checks.
+        if self.fail_next > 0:
+            self.fail_next -= 1
+            self._respond(handler, 500, b"")
+            return
+        try:
+            length = int(handler.headers.get("Content-Length", 0))
+            raw = handler.rfile.read(length) if length else b""
+            body = json.loads(raw.decode("utf-8")) if raw else {}
+        except (ValueError, json.JSONDecodeError):
+            self._respond(handler, 400,
+                          {"status": "ERROR", "message": "Invalid JSON"})
+            return
+        if (body.get("apikey") != self.apikey
+                or body.get("secretapikey") != self.secretapikey):
+            self._respond(handler, 400,
+                          {"status": "ERROR", "message": "Invalid API Keys"})
+            return
+        action, domain, record_id = self._route(handler.path)
+        if action == "retrieve" and domain is not None and record_id is None:
+            self._respond(handler, 200, {
+                "status": "SUCCESS",
+                "records": list(self.records.get(domain, [])),
+            })
+        elif action == "create" and domain is not None and record_id is None:
+            record = self._create_record(domain, body)
+            self._respond(handler, 200,
+                          {"status": "SUCCESS", "id": record["id"]})
+        elif action == "delete" and domain is not None and record_id is not None:
+            self._delete_record(domain, record_id)
+            self._respond(handler, 200, {"status": "SUCCESS"})
+        else:
+            self._respond(handler, 404,
+                          {"status": "ERROR", "message": "Not found"})
+
+    @staticmethod
+    def _route(path: str) -> tuple[str | None, str | None, str | None]:
+        """Split a request path into ``(action, domain, record_id)``.
+
+        Expects ``/api/json/v3/dns/<action>/<domain>[/<id>]``.
+        """
+        parts = path.split("?", 1)[0].strip("/").split("/")
+        if len(parts) >= 5 and parts[:4] == ["api", "json", "v3", "dns"]:
+            action = unquote(parts[4])
+            domain = unquote(parts[5]) if len(parts) > 5 else None
+            record_id = unquote(parts[6]) if len(parts) > 6 else None
+            return action, domain, record_id
+        return None, None, None
+
+    def _create_record(self, domain: str, body: dict) -> dict:
+        """Store a record, mapping the client's ``name`` to the fqdn.
+
+        The real API stores and returns the fully-qualified record name: a
+        body ``name`` of ``"@"`` means the domain itself, anything else is
+        joined to the domain. ``ttl`` is stored as a string, matching what
+        the real API returns.
+        """
+        name = body.get("name", "@")
+        fqdn = domain if name == "@" else f"{name}.{domain}"
+        record = {
+            key: value
+            for key, value in body.items()
+            if key not in ("apikey", "secretapikey", "endpoint", "name")
+        }
+        record["id"] = str(self._next_id)
+        record["name"] = fqdn
+        record["ttl"] = str(record.get("ttl", 600))
+        self._next_id += 1
+        self.records.setdefault(domain, []).append(record)
+        return record
+
+    def _delete_record(self, domain: str, record_id: str) -> None:
+        self.records[domain] = [
+            record for record in self.records.get(domain, [])
+            if record["id"] != record_id
+        ]
+
+    def _respond(self, handler: BaseHTTPRequestHandler, status: int,
+                 payload: dict | bytes) -> None:
+        if isinstance(payload, dict):
+            body_bytes = json.dumps(payload).encode("utf-8")
+            content_type = "application/json"
+            recorded: dict | None = payload
+        else:
+            body_bytes = payload
+            content_type = None
+            recorded = None
+        self.responses.append((handler.path, status, recorded))
+        handler.send_response(status)
+        if content_type:
+            handler.send_header("Content-Type", content_type)
+        handler.send_header("Content-Length", str(len(body_bytes)))
+        handler.end_headers()
+        handler.wfile.write(body_bytes)

--- a/porkbun_ddns/test/test_e2e.py
+++ b/porkbun_ddns/test/test_e2e.py
@@ -1,0 +1,244 @@
+"""Hermetic end-to-end tests for the Porkbun DDNS client.
+
+No real network traffic: the client talks to :class:`PorkbunAPIMock` on
+127.0.0.1 and webhook delivery is captured by a second local HTTP server.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from ipaddress import IPv6Address
+
+import pytest
+
+from porkbun_ddns import PorkbunDDNS
+from porkbun_ddns.config import Config
+from porkbun_ddns.errors import PorkbunDDNS_Error
+from porkbun_ddns.test.mock_porkbun_api import PorkbunAPIMock
+from porkbun_ddns.webhook import fire_webhook
+
+DOMAIN = "example.com"
+
+
+class WebhookCaptureServer:
+    """Captures POST bodies in a thread-safe list; status is configurable."""
+
+    def __init__(self) -> None:
+        self.bodies: list[bytes] = []
+        self.status = 200
+        self._lock = threading.Lock()
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def url(self) -> str:
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def start(self) -> WebhookCaptureServer:
+        self._server = ThreadingHTTPServer(
+            ("127.0.0.1", 0), _make_capture_handler(self))
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        if self._server:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+            self._thread = None
+
+
+def _make_capture_handler(capture: WebhookCaptureServer) -> type[BaseHTTPRequestHandler]:
+    """Build a handler that records POST bodies on the capture server."""
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length) if length else b""
+            with capture._lock:
+                capture.bodies.append(body)
+            self.send_response(capture.status)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *args) -> None:  # silence default request logging
+            pass
+
+    return Handler
+
+
+@pytest.fixture
+def mock_api() -> PorkbunAPIMock:
+    mock = PorkbunAPIMock(apikey="test-apikey", secretapikey="test-secret")
+    mock.start()
+    yield mock
+    mock.stop()
+
+
+@pytest.fixture
+def webhook_capture() -> WebhookCaptureServer:
+    server = WebhookCaptureServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+def make_config(mock: PorkbunAPIMock,
+                webhook_url: str = "",
+                **overrides) -> Config:
+    """Build a Config pointing at the mock, with overridable kwargs."""
+    values = {
+        "endpoint": f"{mock.url}/api/json/v3",
+        "apikey": "test-apikey",
+        "secretapikey": "test-secret",
+        "webhook_url": webhook_url,
+        "retry_count": "3",
+        "retry_delay": "0",
+    }
+    values.update(overrides)
+    return Config(**values)
+
+
+def run_update(config: Config,
+               public_ips: list[str],
+               *,
+               ipv4: bool = True,
+               ipv6: bool = True) -> PorkbunDDNS:
+    """Run one full update pass and return the client instance."""
+    instance = PorkbunDDNS(
+        config, DOMAIN, public_ips=public_ips, ipv4=ipv4, ipv6=ipv6)
+    instance.update_records()
+    return instance
+
+
+def test_ipv4_creates_record_then_idempotent(mock_api):
+    first = run_update(make_config(mock_api), ["203.0.113.5"],
+                       ipv4=True, ipv6=False)
+    assert len(first.changes) == 1
+    assert len(mock_api.records["example.com"]) == 1
+    record = mock_api.records["example.com"][0]
+    assert record["type"] == "A"
+    assert record["name"] == "example.com"
+    assert record["content"] == "203.0.113.5"
+
+    second = run_update(make_config(mock_api), ["203.0.113.5"],
+                        ipv4=True, ipv6=False)
+    assert second.changes == []
+    assert len(mock_api.records["example.com"]) == 1
+    assert mock_api.records["example.com"][0]["content"] == "203.0.113.5"
+
+
+def test_ipv4_ip_change_triggers_delete_and_create(mock_api):
+    run_update(make_config(mock_api), ["203.0.113.5"], ipv4=True, ipv6=False)
+
+    updated = run_update(make_config(mock_api), ["203.0.113.9"],
+                         ipv4=True, ipv6=False)
+    assert len(updated.changes) == 1
+    change = updated.changes[0]
+    assert change["old_ip"] == "203.0.113.5"
+    assert change["new_ip"] == "203.0.113.9"
+    assert mock_api.records["example.com"][0]["content"] == "203.0.113.9"
+
+
+def test_ipv6_aaaa_with_pinned_public_ips(mock_api):
+    expected = IPv6Address("2001:db8::1").exploded
+    first = run_update(make_config(mock_api), ["2001:db8::1"],
+                       ipv4=False, ipv6=True)
+    assert len(first.changes) == 1
+    records = mock_api.records["example.com"]
+    assert len(records) == 1
+    assert records[0]["type"] == "AAAA"
+    assert records[0]["content"] == expected
+
+    second = run_update(make_config(mock_api), ["2001:db8::1"],
+                        ipv4=False, ipv6=True)
+    assert second.changes == []
+    assert mock_api.records["example.com"][0]["content"] == expected
+
+
+def test_retry_succeeds_after_transient_500s(mock_api):
+    mock_api.fail_next = 2
+    instance = run_update(make_config(mock_api, retry_count="3"),
+                          ["203.0.113.5"], ipv4=True, ipv6=False)
+    assert len(instance.changes) == 1
+    assert len(mock_api.records["example.com"]) == 1
+    # 3 retrieve attempts (2 x 500, 1 x 200) + create + post-create retrieve.
+    assert mock_api.request_count == 5
+
+
+def test_retry_gives_up_after_retry_count(mock_api):
+    mock_api.fail_next = 5
+    with pytest.raises(PorkbunDDNS_Error):
+        run_update(make_config(mock_api, retry_count="3"),
+                   ["203.0.113.5"], ipv4=True, ipv6=False)
+    assert mock_api.request_count == 3
+
+
+def test_invalid_api_keys_fail_fast(mock_api):
+    with pytest.raises(PorkbunDDNS_Error, match="Invalid API Keys"):
+        run_update(make_config(mock_api, apikey="wrong"),
+                   ["203.0.113.5"], ipv4=True, ipv6=False)
+    assert mock_api.request_count == 1
+
+
+def test_webhook_sent_on_change_default_template(mock_api, webhook_capture):
+    config = make_config(mock_api, webhook_url=webhook_capture.url)
+    instance = run_update(config, ["203.0.113.5"], ipv4=True, ipv6=False)
+    assert fire_webhook(config, instance.changes, instance.domain)
+    assert len(webhook_capture.bodies) == 1
+    payload = json.loads(webhook_capture.bodies[0].decode("utf-8"))
+    assert payload == {"text": "IP changed:  -> 203.0.113.5 (example.com)"}
+
+
+def test_webhook_inline_template(mock_api, webhook_capture):
+    config = make_config(
+        mock_api,
+        webhook_url=webhook_capture.url,
+        webhook_template='{"msg": "{{ new_ips | join(", ") }} for {{ domain }}"}',
+    )
+    instance = run_update(config, ["203.0.113.5"], ipv4=True, ipv6=False)
+    assert fire_webhook(config, instance.changes, instance.domain)
+    assert len(webhook_capture.bodies) == 1
+    payload = json.loads(webhook_capture.bodies[0].decode("utf-8"))
+    assert payload == {"msg": "203.0.113.5 for example.com"}
+
+
+def test_webhook_template_file_precedence(mock_api, webhook_capture, tmp_path):
+    template_file = tmp_path / "template.j2"
+    template_file.write_text('{"from": "file", "domain": "{{ domain }}"}')
+    config = make_config(
+        mock_api,
+        webhook_url=webhook_capture.url,
+        webhook_template='{"from": "inline"}',
+        webhook_template_file=str(template_file),
+    )
+    instance = run_update(config, ["203.0.113.5"], ipv4=True, ipv6=False)
+    assert fire_webhook(config, instance.changes, instance.domain)
+    assert len(webhook_capture.bodies) == 1
+    payload = json.loads(webhook_capture.bodies[0].decode("utf-8"))
+    assert payload == {"from": "file", "domain": "example.com"}
+
+
+def test_webhook_fire_and_forget_on_failure(mock_api, webhook_capture):
+    webhook_capture.status = 500
+    config = make_config(mock_api, webhook_url=webhook_capture.url)
+    instance = run_update(config, ["203.0.113.5"], ipv4=True, ipv6=False)
+    # The webhook server's 500 must not propagate to the caller.
+    assert fire_webhook(config, instance.changes, instance.domain)
+    assert len(webhook_capture.bodies) == 1
+
+
+def test_no_webhook_when_no_changes(mock_api, webhook_capture):
+    config = make_config(mock_api, webhook_url=webhook_capture.url)
+    first = run_update(config, ["203.0.113.5"], ipv4=True, ipv6=False)
+    assert fire_webhook(config, first.changes, first.domain)
+    assert len(webhook_capture.bodies) == 1
+
+    second = run_update(config, ["203.0.113.5"], ipv4=True, ipv6=False)
+    assert second.changes == []
+    assert not fire_webhook(config, second.changes, second.domain)
+    assert len(webhook_capture.bodies) == 1

--- a/porkbun_ddns/test/test_live_api.py
+++ b/porkbun_ddns/test/test_live_api.py
@@ -1,0 +1,123 @@
+"""Network-dependent tests against the live Porkbun API and its spec.
+
+These tests skip when the network is unreachable and are not part of the
+hermetic suite. They keep the client's default endpoint and the mock honest.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import urllib.request
+
+import pytest
+
+from porkbun_ddns import PorkbunDDNS
+from porkbun_ddns.config import DEFAULT_ENDPOINT, Config
+from porkbun_ddns.test.mock_porkbun_api import PorkbunAPIMock
+
+SPEC_URL = "https://porkbun.com/api/json/v3/spec"
+
+DNS_ENDPOINTS = (
+    "/dns/retrieve/{domain}",
+    "/dns/create/{domain}",
+    "/dns/delete/{domain}/{id}",
+)
+
+
+def _require_network() -> None:
+    """Skip the test when the live API is unreachable."""
+    try:
+        socket.create_connection(("api.porkbun.com", 443), timeout=5)
+    except OSError:
+        pytest.skip("No network access; skipping live API tests")
+
+
+def _fetch_spec() -> dict:
+    with urllib.request.urlopen(SPEC_URL, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _resolve_200_schema(spec: dict, path: str) -> dict:
+    """Extract the POST-200 response schema, resolving one level of $ref."""
+    schema = spec["paths"][path]["post"]["responses"]["200"][
+        "content"]["application/json"]["schema"]
+    if "$ref" in schema:
+        name = schema["$ref"].rsplit("/", 1)[-1]
+        return spec["components"]["schemas"][name]
+    return schema
+
+
+def _schema_for_path(path: str, schemas: dict) -> dict | None:
+    if "/dns/retrieve/" in path:
+        return schemas["retrieve"]
+    if "/dns/create/" in path:
+        return schemas["create"]
+    if "/dns/delete/" in path:
+        return schemas["delete"]
+    return None
+
+
+def test_default_endpoint_reachable():
+    _require_network()
+    request = urllib.request.Request(
+        DEFAULT_ENDPOINT + "/ping",
+        data=json.dumps({}).encode("utf-8"),
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        assert response.getcode() == 200
+        body = json.loads(response.read().decode("utf-8"))
+    assert body["status"] == "SUCCESS"
+
+
+def test_mock_matches_spec():
+    _require_network()
+    try:
+        import jsonschema
+    except ImportError:  # pragma: no cover - CI installs it
+        pytest.skip("jsonschema not installed; skipping spec conformance test")
+
+    spec = _fetch_spec()
+    schemas = {
+        endpoint.split("/")[2]: _resolve_200_schema(spec, endpoint)
+        for endpoint in DNS_ENDPOINTS
+    }
+
+    mock = PorkbunAPIMock(apikey="test-apikey", secretapikey="test-secret")
+    mock.start()
+    try:
+        mock.records["example.com"] = [
+            {"id": "1", "name": "example.com", "type": "A",
+             "content": "203.0.113.5", "ttl": "600"},
+        ]
+        config = Config(
+            endpoint=f"{mock.url}/api/json/v3",
+            apikey="test-apikey",
+            secretapikey="test-secret",
+            retry_count="3",
+            retry_delay="0",
+        )
+        # One update pass with a changed IP drives retrieve, delete and create.
+        PorkbunDDNS(
+            config, "example.com", public_ips=["203.0.113.9"],
+            ipv4=True, ipv6=False,
+        ).update_records()
+    finally:
+        mock.stop()
+
+    failures = []
+    for path, status, body in mock.responses:
+        schema = _schema_for_path(path, schemas)
+        if schema is None:
+            failures.append(f"no schema found for {path}")
+            continue
+        try:
+            jsonschema.validate(body, schema)
+        except jsonschema.ValidationError as err:
+            failures.append(f"{path} ({status}): {err.message}")
+    if failures:
+        pytest.fail(
+            "Mock responses do not conform to the live API spec:\n"
+            + "\n".join(failures)
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ repository = "https://github.com/mietzen/porkbun-ddns"
 [project.scripts]
 porkbun-ddns = "porkbun_ddns.cli:main"
 
+[project.optional-dependencies]
+test = ["jsonschema"]
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## What
Hermetic end-to-end test coverage for all client features, plus network-based canaries that keep the default endpoint and the test mock honest.

## Why
The client's features (retry, webhooks, IPv4/IPv6 updates) were only unit-tested. This adds a real request-path e2e suite that runs against a focused mock of the Porkbun JSON API v3 — no real API keys, no real DNS records, no network — plus scheduled checks that the official endpoint is alive and the mock still conforms to the official OpenAPI spec.

## Changes
- `porkbun_ddns/test/mock_porkbun_api.py` — stdlib-only fake of the 3 DNS endpoints the client calls (retrieve/create/delete), with auth validation and `fail_next` fault injection. Response shapes sourced from https://porkbun.com/api/json/v3/spec.
- `porkbun_ddns/test/test_e2e.py` — 11 hermetic e2e tests: IPv4 create/idempotency/IP-change, IPv6 AAAA (pinned PUBLIC_IPS, runs on any host), retry success/give-up/fast-fail, webhook default/inline/template-file/fire-and-forget.
- `porkbun_ddns/test/test_live_api.py` — 2 network tests (skip when offline, hard-fail on drift): default endpoint reachable; mock responses validated against the live spec via `jsonschema`.
- `.github/workflows/api-canary.yml` — daily cron running the live tests.
- `pyproject.toml` + `lint_and_test.yml` — `jsonschema` test dependency.
- `docs/adr/0001-focused-porkbun-api-mock-for-e2e-tests.md` + `CONTEXT.md` — decision record and glossary.

## Testing
- pytest: 62 passed + 13 subtests (49 existing + 11 e2e + 2 live, live tests verified against the real spec)
- ruff: clean