### PR TITLE
Add e2e coverage for RETRY_COUNT and RETRY_DELAY

### DIFF
--- a/Docker/test/e2e.sh
+++ b/Docker/test/e2e.sh
@@ -230,4 +230,39 @@ if grep -qE "INFO|DEBUG" <<< "${LOG5B}"; then
     fail "scenario 5: INFO/DEBUG lines present with LOG_LEVEL=WARNING"
 fi
 
-echo "Docker e2e PASSED: ${IMAGE} (ip-change, ipv6, validation, subdomains, log-levels)"
+echo "Docker e2e - scenario 6: RETRY_COUNT and RETRY_DELAY drive the retry loop"
+
+stop_app
+
+# Point at a closed port on the mock so every attempt fails fast with a
+# connection error; the container must retry RETRY_COUNT times, sleeping
+# RETRY_DELAY seconds between attempts, then exit non-zero.
+START=$(date +%s)
+if docker run --rm --name ${APP_CONTAINER} \
+    --platform ${PLATFORM} \
+    --network ${NETWORK} \
+    -e DOMAIN=example.com \
+    -e APIKEY=${APIKEY} \
+    -e SECRETAPIKEY=${SECRETAPIKEY} \
+    -e API_ENDPOINT="http://${MOCK_CONTAINER}:8001/api/json/v3" \
+    -e PUBLIC_IPS=${PINNED_IP} \
+    -e IPV6=FALSE \
+    -e RETRY_COUNT=3 \
+    -e RETRY_DELAY=1 \
+    "${IMAGE}" > "${LOG_DIR}/retry.log" 2>&1; then
+    fail "scenario 6: container should exit non-zero after exhausting retries"
+fi
+END=$(date +%s)
+
+grep -q "attempt 1/3" "${LOG_DIR}/retry.log" \
+    || fail "scenario 6: missing 'attempt 1/3' retry log line"
+grep -q "attempt 2/3" "${LOG_DIR}/retry.log" \
+    || fail "scenario 6: missing 'attempt 2/3' retry log line"
+grep -q "Error reaching" "${LOG_DIR}/retry.log" \
+    || fail "scenario 6: missing connection error in log"
+
+ELAPSED=$((END - START))
+[[ ${ELAPSED} -ge 2 ]] \
+    || fail "scenario 6: expected >=2s wall time for RETRY_DELAY=1 x 2 sleeps, got ${ELAPSED}s"
+
+echo "Docker e2e PASSED: ${IMAGE} (ip-change, ipv6, validation, subdomains, log-levels, retry)"

--- a/porkbun_ddns/test/test_e2e.py
+++ b/porkbun_ddns/test/test_e2e.py
@@ -7,13 +7,14 @@ No real network traffic: the client talks to :class:`PorkbunAPIMock` on
 from __future__ import annotations
 
 import json
+import logging
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from ipaddress import IPv6Address
 
 import pytest
 
-from porkbun_ddns import PorkbunDDNS
+from porkbun_ddns import PorkbunDDNS, cli
 from porkbun_ddns.config import Config
 from porkbun_ddns.errors import PorkbunDDNS_Error
 from porkbun_ddns.test.mock_porkbun_api import PorkbunAPIMock
@@ -242,3 +243,60 @@ def test_no_webhook_when_no_changes(mock_api, webhook_capture):
     assert second.changes == []
     assert not fire_webhook(config, second.changes, second.domain)
     assert len(webhook_capture.bodies) == 1
+
+
+def test_cli_retry_flags_recover_after_transient_failures(mock_api, caplog):
+    mock_api.fail_next = 2
+    caplog.set_level(logging.WARNING)
+    cli.main([
+        "example.com", "--env_only",
+        "--endpoint", f"{mock_api.url}/api/json/v3",
+        "--apikey", "test-apikey",
+        "--secretapikey", "test-secret",
+        "--public-ips", "203.0.113.5",
+        "--ipv4-only",
+        "--retry-count", "3",
+        "--retry-delay", "0",
+    ])
+    # 3 retrieve attempts (2 x 500 + success), create, post-create retrieve.
+    assert mock_api.request_count == 5
+    assert mock_api.records["example.com"][0]["content"] == "203.0.113.5"
+    assert "Retrying in 0 seconds (attempt 1/3)" in caplog.text
+    assert "Retrying in 0 seconds (attempt 2/3)" in caplog.text
+
+
+def test_cli_env_vars_plumb_retry_settings(mock_api, monkeypatch, caplog):
+    monkeypatch.setenv("PORKBUN_ENDPOINT", f"{mock_api.url}/api/json/v3")
+    monkeypatch.setenv("PORKBUN_APIKEY", "test-apikey")
+    monkeypatch.setenv("PORKBUN_SECRETAPIKEY", "test-secret")
+    monkeypatch.setenv("PORKBUN_RETRY_COUNT", "3")
+    monkeypatch.setenv("PORKBUN_RETRY_DELAY", "0")
+    mock_api.fail_next = 1
+    caplog.set_level(logging.WARNING)
+    cli.main([
+        "example.com", "--env_only",
+        "--public-ips", "203.0.113.5",
+        "--ipv4-only",
+    ])
+    assert mock_api.records["example.com"][0]["content"] == "203.0.113.5"
+    assert "attempt 1/3" in caplog.text
+
+
+def test_cli_retry_exhausted_exits_nonzero(mock_api, caplog):
+    mock_api.fail_next = 5
+    caplog.set_level(logging.WARNING)
+    with pytest.raises(SystemExit) as exc:
+        cli.main([
+            "example.com", "--env_only",
+            "--endpoint", f"{mock_api.url}/api/json/v3",
+            "--apikey", "test-apikey",
+            "--secretapikey", "test-secret",
+            "--public-ips", "203.0.113.5",
+            "--ipv4-only",
+            "--retry-count", "2",
+            "--retry-delay", "0",
+        ])
+    assert exc.value.code == 1
+    assert mock_api.request_count == 2
+    assert "attempt 1/2" in caplog.text
+    assert "Error reaching" in caplog.text


### PR DESCRIPTION
Adds e2e coverage for RETRY_COUNT / RETRY_DELAY at both layers:

**CLI / python (test_e2e.py, 3 new tests):**
- `test_cli_retry_flags_recover_after_transient_failures` — real `cli.main()` against the mock with `--retry-count 3 --retry-delay 0`: recovers after 2x HTTP 500, creates the record, and the retry warnings show `Retrying in 0 seconds (attempt 1/3)` / `attempt 2/3` (proves both settings reach the retry loop)
- `test_cli_env_vars_plumb_retry_settings` — `PORKBUN_RETRY_COUNT` / `PORKBUN_RETRY_DELAY` env vars reach the retry loop via `_Config`'s env path
- `test_cli_retry_exhausted_exits_nonzero` — retries bounded by `--retry-count`; exhaustion logs the error and exits 1 (SystemExit code verified)

**Container (e2e.sh, scenario 6):**
- Runs the real image with `API_ENDPOINT` pointing at a closed port on the mock (fast connection-refused, no timeout waits) with `RETRY_COUNT=3 RETRY_DELAY=1`
- Asserts: container exits non-zero after exhausting retries, log contains `attempt 1/3` + `attempt 2/3`, and wall time >= 2s (proving the delay sleeps actually happen)

Verified locally: 65 passed + 13 subtests, ruff clean, all 6 e2e scenarios pass against a locally built image.
